### PR TITLE
Fix Playwright browser closure

### DIFF
--- a/fastmcp_server.py
+++ b/fastmcp_server.py
@@ -86,37 +86,37 @@ async def capture_coinglass_heatmap(symbol: str = "BTC", time_period: str = "24 
 
             await page.wait_for_timeout(5000)
         
-        if symbol != "BTC":
-            try:
-                await page.click("//button[@role='tab' and contains(text(), 'Symbol')]")
-                await page.wait_for_timeout(2000)
-                await page.fill("input.MuiAutocomplete-input", symbol)
-                await page.wait_for_timeout(2000)
+            if symbol != "BTC":
                 try:
-                    await page.click(f"//li[@role='option' and text()='{symbol}']")
-                except Exception:
-                    await page.keyboard.press("Enter")
-                await page.wait_for_timeout(15000)
-            except Exception as symbol_e:
-                logger.warning(f"Could not select symbol {symbol}: {symbol_e}")
-
-        current_time = (await page.inner_text("div.MuiSelect-root button.MuiSelect-button")).strip()
-        if current_time != time_period:
-            await page.click("div.MuiSelect-root button.MuiSelect-button")
-            await page.wait_for_timeout(2000)
-            await page.evaluate(
-                '(tp) => { const opts = document.querySelectorAll("li[role=\"option\"]"); for (const o of opts) { if (o.textContent.includes(tp)) { o.click(); break; } } }',
-                time_period,
-            )
-            await page.wait_for_timeout(3000)
-
-        heatmap = await page.wait_for_selector("div.echarts-for-react")
-        box = await heatmap.bounding_box()
-
-        png_data = await page.screenshot(clip=box, type="png")
-
-        await browser.close()
-        return png_data
+                    await page.click("//button[@role='tab' and contains(text(), 'Symbol')]")
+                    await page.wait_for_timeout(2000)
+                    await page.fill("input.MuiAutocomplete-input", symbol)
+                    await page.wait_for_timeout(2000)
+                    try:
+                        await page.click(f"//li[@role='option' and text()='{symbol}']")
+                    except Exception:
+                        await page.keyboard.press("Enter")
+                    await page.wait_for_timeout(15000)
+                except Exception as symbol_e:
+                    logger.warning(f"Could not select symbol {symbol}: {symbol_e}")
+    
+            current_time = (await page.inner_text("div.MuiSelect-root button.MuiSelect-button")).strip()
+            if current_time != time_period:
+                await page.click("div.MuiSelect-root button.MuiSelect-button")
+                await page.wait_for_timeout(2000)
+                await page.evaluate(
+                    '(tp) => { const opts = document.querySelectorAll("li[role=\"option\"]"); for (const o of opts) { if (o.textContent.includes(tp)) { o.click(); break; } } }',
+                    time_period,
+                )
+                await page.wait_for_timeout(3000)
+    
+            heatmap = await page.wait_for_selector("div.echarts-for-react")
+            box = await heatmap.bounding_box()
+    
+            png_data = await page.screenshot(clip=box, type="png")
+    
+            await browser.close()
+            return png_data
 
     except Exception as e:
         logger.error(f"Error capturing heatmap: {e}")


### PR DESCRIPTION
## Summary
- keep Playwright context open when selecting symbol and timeframe in `fastmcp_server`

## Testing
- `python test_mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_688a225528d48332ba32773456cb3077