### PR TITLE
Refine symbol selection waits

### DIFF
--- a/fastmcp_server.py
+++ b/fastmcp_server.py
@@ -74,7 +74,10 @@ async def capture_coinglass_heatmap(symbol: str = "BTC", time_period: str = "24 
             )
             page = await context.new_page()
 
-            await page.goto("https://www.coinglass.com/pro/futures/LiquidationHeatMap")
+            await page.goto(
+                "https://www.coinglass.com/pro/futures/LiquidationHeatMap",
+                timeout=60000,
+            )
 
             await page.add_style_tag(
                 content="""
@@ -84,39 +87,40 @@ async def capture_coinglass_heatmap(symbol: str = "BTC", time_period: str = "24 
                 """
             )
 
-            await page.wait_for_timeout(5000)
+            await page.wait_for_load_state("networkidle")
         
-        if symbol != "BTC":
-            try:
-                await page.click("//button[@role='tab' and contains(text(), 'Symbol')]")
-                await page.wait_for_timeout(2000)
-                await page.fill("input.MuiAutocomplete-input", symbol)
-                await page.wait_for_timeout(2000)
+            if symbol != "BTC":
                 try:
-                    await page.click(f"//li[@role='option' and text()='{symbol}']")
-                except Exception:
-                    await page.keyboard.press("Enter")
-                await page.wait_for_timeout(15000)
-            except Exception as symbol_e:
-                logger.warning(f"Could not select symbol {symbol}: {symbol_e}")
-
-        current_time = (await page.inner_text("div.MuiSelect-root button.MuiSelect-button")).strip()
-        if current_time != time_period:
-            await page.click("div.MuiSelect-root button.MuiSelect-button")
-            await page.wait_for_timeout(2000)
-            await page.evaluate(
-                '(tp) => { const opts = document.querySelectorAll("li[role=\"option\"]"); for (const o of opts) { if (o.textContent.includes(tp)) { o.click(); break; } } }',
-                time_period,
-            )
-            await page.wait_for_timeout(3000)
-
-        heatmap = await page.wait_for_selector("div.echarts-for-react")
-        box = await heatmap.bounding_box()
-
-        png_data = await page.screenshot(clip=box, type="png")
-
-        await browser.close()
-        return png_data
+                    await page.click("//button[@role='tab' and contains(text(), 'Symbol')]")
+                    await page.wait_for_selector("input.MuiAutocomplete-input")
+                    await page.fill("input.MuiAutocomplete-input", symbol)
+                    try:
+                        await page.click(
+                            f"//li[@role='option' and text()='{symbol}']",
+                            timeout=5000,
+                        )
+                    except Exception:
+                        await page.keyboard.press("Enter")
+                    await page.wait_for_load_state("networkidle")
+                except Exception as symbol_e:
+                    logger.warning(f"Could not select symbol {symbol}: {symbol_e}")
+    
+            current_time = (await page.inner_text("div.MuiSelect-root button.MuiSelect-button")).strip()
+            if current_time != time_period:
+                await page.click("div.MuiSelect-root button.MuiSelect-button")
+                await page.wait_for_selector("li[role='option']")
+                await page.click(
+                    f"//li[@role='option' and contains(text(), '{time_period}')]"
+                )
+                await page.wait_for_load_state("networkidle")
+    
+            heatmap = await page.wait_for_selector("div.echarts-for-react")
+            box = await heatmap.bounding_box()
+    
+            png_data = await page.screenshot(clip=box, type="png")
+    
+            await browser.close()
+            return png_data
 
     except Exception as e:
         logger.error(f"Error capturing heatmap: {e}")

--- a/liquidation_map_mcp_server.py
+++ b/liquidation_map_mcp_server.py
@@ -109,7 +109,10 @@ class LiquidationMapMCPServer:
                 )
                 page = await context.new_page()
 
-                await page.goto("https://www.coinglass.com/pro/futures/LiquidationHeatMap")
+                await page.goto(
+                    "https://www.coinglass.com/pro/futures/LiquidationHeatMap",
+                    timeout=60000,
+                )
 
                 await page.add_style_tag(
                     content="""
@@ -119,19 +122,21 @@ class LiquidationMapMCPServer:
                     """
                 )
 
-                await page.wait_for_timeout(5000)
+                await page.wait_for_load_state("networkidle")
 
                 if symbol != "BTC":
                     try:
                         await page.click("//button[@role='tab' and contains(text(), 'Symbol')]")
-                        await page.wait_for_timeout(2000)
+                        await page.wait_for_selector("input.MuiAutocomplete-input")
                         await page.fill("input.MuiAutocomplete-input", symbol)
-                        await page.wait_for_timeout(2000)
                         try:
-                            await page.click(f"//li[@role='option' and text()='{symbol}']")
+                            await page.click(
+                                f"//li[@role='option' and text()='{symbol}']",
+                                timeout=5000,
+                            )
                         except Exception:
                             await page.keyboard.press("Enter")
-                        await page.wait_for_timeout(15000)
+                        await page.wait_for_load_state("networkidle")
                     except Exception as symbol_e:
                         logger.warning(f"Could not select symbol {symbol}: {symbol_e}")
 
@@ -140,12 +145,11 @@ class LiquidationMapMCPServer:
                 ).strip()
                 if current_time != time_period:
                     await page.click("div.MuiSelect-root button.MuiSelect-button")
-                    await page.wait_for_timeout(2000)
-                    await page.evaluate(
-                        "(tp) => { const opts = document.querySelectorAll('li[role=\"option\"]'); for (const o of opts) { if (o.textContent.includes(tp)) { o.click(); break; } } }",
-                        time_period,
+                    await page.wait_for_selector("li[role='option']")
+                    await page.click(
+                        f"//li[@role='option' and contains(text(), '{time_period}')]",
                     )
-                    await page.wait_for_timeout(3000)
+                    await page.wait_for_load_state("networkidle")
 
                 heatmap = await page.wait_for_selector("div.echarts-for-react")
                 box = await heatmap.bounding_box()


### PR DESCRIPTION
## Summary
- avoid fixed 2s waits when picking a symbol
- wait for autocomplete input to appear before filling

## Testing
- `python test_mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_688a225528d48332ba32773456cb3077