### PR TITLE
Handle BrowserCat failures with explicit status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ curl "http://localhost:5001/api/get_crypto_price?symbol=BTC"
 **Parameters**:
 - `symbol` (string, required): Cryptocurrency symbol (e.g., "BTC", "ETH")
 - `time_period` (string, optional, default: "24 hour"): Time period ("12 hour", "24 hour", "1 month", "3 month")
+- `allow_simulated` (boolean, optional): When `true`, include a simulated payload if BrowserCat is unavailable.
 
 **Example Request**:
 ```bash
@@ -48,13 +49,35 @@ curl "http://localhost:5001/api/capture_heatmap?symbol=BTC&time_period=24%20hour
 **Example Response**:
 ```json
 {
-  "image_path": "/tmp/btc_liquidation_heatmap_20250802_013339_24_hour.png",
+  "image_path": "/tmp/heatmap.png",
   "symbol": "BTC",
   "time_period": "24 hour",
-  "note": "BrowserCat capture failed: Request failed with status 401. Returning simulated response.",
-  "browsercat_error": "Request failed with status 401"
+  "browsercat_result": {
+    "screenshot_path": "/tmp/heatmap.png"
+  }
 }
 ```
+
+**Example BrowserCat Failure (HTTP 502)**:
+
+```json
+{
+  "error": "Failed to capture heatmap via BrowserCat.",
+  "browsercat_error": "Request failed with status 401",
+  "symbol": "BTC",
+  "time_period": "24 hour",
+  "fallback_provided": true,
+  "fallback": {
+    "image_path": "/tmp/btc_liquidation_heatmap_20250802_013339_24_hour.png",
+    "symbol": "BTC",
+    "time_period": "24 hour",
+    "note": "Simulated heatmap placeholder generated without BrowserCat.",
+    "simulated": true
+  }
+}
+```
+
+Use the `allow_simulated=true` query parameter (or set the `ENABLE_SIMULATED_HEATMAP=true` environment variable) to include the fallback payload for local development. Production environments should rely on the HTTP 502/503 status codes without the simulated payload.
 
 ### 3. Health Check
 

--- a/src/routes/crypto.py
+++ b/src/routes/crypto.py
@@ -6,6 +6,9 @@ from datetime import datetime
 import logging
 from src.services.browsercat_client import browsercat_client
 
+_TRUTHY_STRINGS = {'1', 'true', 'yes', 'on'}
+_FALSY_STRINGS = {'0', 'false', 'no', 'off'}
+
 crypto_bp = Blueprint('crypto', __name__)
 
 # Configure logging
@@ -70,6 +73,38 @@ def get_crypto_price():
         logger.error(f"Error fetching {symbol} price: {e}")
         return jsonify({'error': str(e)}), 500
 
+def _parse_bool(value):
+    """Parse common truthy/falsey values to booleans."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        lower_value = value.strip().lower()
+        if lower_value in _TRUTHY_STRINGS:
+            return True
+        if lower_value in _FALSY_STRINGS:
+            return False
+    return None
+
+
+def _build_simulated_payload(symbol: str, time_period: str):
+    """Create a simulated heatmap payload used for non-production fallbacks."""
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    image_filename = f"{symbol.lower()}_liquidation_heatmap_{timestamp}_{time_period.replace(' ', '_')}.png"
+    simulated_path = f"/tmp/{image_filename}"
+
+    return {
+        'image_path': simulated_path,
+        'symbol': symbol,
+        'time_period': time_period,
+        'note': 'Simulated heatmap placeholder generated without BrowserCat.',
+        'simulated': True
+    }
+
+
 @crypto_bp.route('/capture_heatmap', methods=['GET', 'POST'])
 def capture_heatmap():
     """
@@ -87,36 +122,43 @@ def capture_heatmap():
         if request.method == 'GET':
             symbol = request.args.get('symbol', 'BTC')
             time_period = request.args.get('time_period', '24 hour')
+            allow_simulated_param = request.args.get('allow_simulated')
         else:  # POST
             data = request.get_json()
             symbol = data.get('symbol', 'BTC') if data else 'BTC'
             time_period = data.get('time_period', '24 hour') if data else '24 hour'
-        
+            allow_simulated_param = data.get('allow_simulated') if data else None
+
         symbol = symbol.upper()
-        
+
         # Validate time period
         valid_timeframes = ["12 hour", "24 hour", "1 month", "3 month"]
         if time_period not in valid_timeframes:
             return jsonify({'error': f'Invalid timeframe. Use: {", ".join(valid_timeframes)}'}), 400
-        
+
+        allow_simulated_override = _parse_bool(allow_simulated_param)
+        env_allow_simulated = _parse_bool(os.getenv('ENABLE_SIMULATED_HEATMAP'))
+        allow_simulated = allow_simulated_override if allow_simulated_override is not None else bool(env_allow_simulated)
+
         # Use BrowserCat MCP client to capture heatmap
         try:
             heatmap_result = browsercat_client.capture_coinglass_heatmap(symbol, time_period)
-            
+
             if "error" in heatmap_result:
                 logger.error(f"BrowserCat heatmap capture failed: {heatmap_result['error']}")
-                # Fallback to simulated response
-                timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-                image_filename = f"{symbol.lower()}_liquidation_heatmap_{timestamp}_{time_period.replace(' ', '_')}.png"
-                simulated_path = f"/tmp/{image_filename}"
-                
-                return jsonify({
-                    'image_path': simulated_path,
+                response_payload = {
+                    'error': 'Failed to capture heatmap via BrowserCat.',
+                    'browsercat_error': heatmap_result['error'],
                     'symbol': symbol,
                     'time_period': time_period,
-                    'note': f'BrowserCat capture failed: {heatmap_result["error"]}. Returning simulated response.',
-                    'browsercat_error': heatmap_result['error']
-                })
+                    'fallback_provided': False
+                }
+
+                if allow_simulated:
+                    response_payload['fallback'] = _build_simulated_payload(symbol, time_period)
+                    response_payload['fallback_provided'] = True
+
+                return jsonify(response_payload), 502
             else:
                 # Success - return actual screenshot path
                 return jsonify({
@@ -128,18 +170,19 @@ def capture_heatmap():
                 
         except Exception as browsercat_error:
             logger.error(f"BrowserCat client error: {browsercat_error}")
-            # Fallback to simulated response
-            timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-            image_filename = f"{symbol.lower()}_liquidation_heatmap_{timestamp}_{time_period.replace(' ', '_')}.png"
-            simulated_path = f"/tmp/{image_filename}"
-            
-            return jsonify({
-                'image_path': simulated_path,
+            response_payload = {
+                'error': 'BrowserCat client error while capturing heatmap.',
+                'browsercat_error': str(browsercat_error),
                 'symbol': symbol,
                 'time_period': time_period,
-                'note': f'BrowserCat client error: {str(browsercat_error)}. Returning simulated response.',
-                'browsercat_error': str(browsercat_error)
-            })
+                'fallback_provided': False
+            }
+
+            if allow_simulated:
+                response_payload['fallback'] = _build_simulated_payload(symbol, time_period)
+                response_payload['fallback_provided'] = True
+
+            return jsonify(response_payload), 503
         
     except Exception as e:
         logger.error(f"Error capturing heatmap: {e}")

--- a/tests/test_capture_heatmap.py
+++ b/tests/test_capture_heatmap.py
@@ -1,0 +1,67 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from flask import Flask
+
+from src.routes.crypto import crypto_bp
+
+
+class CaptureHeatmapRouteTests(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop('ENABLE_SIMULATED_HEATMAP', None)
+        app = Flask(__name__)
+        app.register_blueprint(crypto_bp, url_prefix='/api')
+        self.client = app.test_client()
+
+    def tearDown(self):
+        os.environ.pop('ENABLE_SIMULATED_HEATMAP', None)
+
+    @patch('src.routes.crypto.browsercat_client.capture_coinglass_heatmap')
+    def test_capture_heatmap_success(self, mock_capture):
+        mock_capture.return_value = {'screenshot_path': '/tmp/test.png'}
+
+        response = self.client.get('/api/capture_heatmap?symbol=BTC&time_period=24%20hour')
+
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(data['image_path'], '/tmp/test.png')
+        self.assertEqual(data['symbol'], 'BTC')
+        self.assertEqual(data['time_period'], '24 hour')
+        self.assertNotIn('fallback', data)
+        mock_capture.assert_called_once_with('BTC', '24 hour')
+
+    @patch('src.routes.crypto.browsercat_client.capture_coinglass_heatmap')
+    def test_capture_heatmap_browsercat_failure_without_fallback(self, mock_capture):
+        mock_capture.return_value = {'error': 'Request failed with status 401'}
+
+        response = self.client.get('/api/capture_heatmap?symbol=ETH&time_period=12%20hour')
+
+        self.assertEqual(response.status_code, 502)
+        data = response.get_json()
+        self.assertFalse(data['fallback_provided'])
+        self.assertNotIn('fallback', data)
+        self.assertEqual(data['browsercat_error'], 'Request failed with status 401')
+        mock_capture.assert_called_once_with('ETH', '12 hour')
+
+    @patch('src.routes.crypto.browsercat_client.capture_coinglass_heatmap')
+    def test_capture_heatmap_browsercat_exception_with_fallback(self, mock_capture):
+        mock_capture.side_effect = RuntimeError('network outage')
+
+        response = self.client.get('/api/capture_heatmap?symbol=SOL&time_period=24%20hour&allow_simulated=true')
+
+        self.assertEqual(response.status_code, 503)
+        data = response.get_json()
+        self.assertTrue(data['fallback_provided'])
+        self.assertIn('fallback', data)
+        self.assertEqual(data['browsercat_error'], 'network outage')
+
+        fallback = data['fallback']
+        self.assertEqual(fallback['symbol'], 'SOL')
+        self.assertEqual(fallback['time_period'], '24 hour')
+        self.assertTrue(fallback['simulated'])
+        self.assertTrue(fallback['image_path'].startswith('/tmp/sol_liquidation_heatmap_'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- return 502/503 responses from the heatmap endpoint when BrowserCat fails and gate simulated payloads behind a toggle
- document the new allow_simulated flag and failure example in the README
- add unit tests that cover success, BrowserCat error, and exception scenarios for the capture_heatmap route

## Testing
- python -m unittest tests.test_capture_heatmap

------
https://chatgpt.com/codex/tasks/task_e_68d2adeaa38883328507786530272e63