### PR TITLE
Add Ruff linting and clean unused imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Ruff
+        run: ruff check .

--- a/README.md
+++ b/README.md
@@ -213,6 +213,17 @@ curl "http://localhost:5001/api/get_crypto_price?symbol=BTC"
 curl "http://localhost:5001/api/capture_heatmap?symbol=ETH&time_period=24%20hour"
 ```
 
+### Linting
+
+We use [Ruff](https://docs.astral.sh/ruff/) to enforce import cleanliness and other Python style rules. Run the linter before
+opening a pull request:
+
+```bash
+ruff check .
+```
+
+Use `ruff check --fix .` to automatically resolve simple issues such as unused imports.
+
 ### Development Mode
 
 The server runs in debug mode by default, providing:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.2
 requests==2.32.4
+ruff==0.7.1
 SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 urllib3==2.5.0

--- a/src/routes/crypto.py
+++ b/src/routes/crypto.py
@@ -1,9 +1,9 @@
-from flask import Blueprint, jsonify, request
-import requests
-import os
-import time
-from datetime import datetime
 import logging
+import os
+from datetime import datetime
+
+import requests
+from flask import Blueprint, jsonify, request
 from src.services.browsercat_client import browsercat_client
 
 _TRUTHY_STRINGS = {'1', 'true', 'yes', 'on'}

--- a/src/services/browsercat_client.py
+++ b/src/services/browsercat_client.py
@@ -5,11 +5,11 @@ This module provides a client interface to interact with the BrowserCat MCP serv
 for browser automation tasks like navigation, screenshot capture, and JavaScript execution.
 """
 
-import requests
-import json
-import os
 import logging
-from typing import Optional, Dict, Any
+import os
+from typing import Any, Dict, Optional
+
+import requests
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove unused imports from the BrowserCat client service and crypto routes
- add Ruff to the dependencies and document the linting workflow for contributors
- configure GitHub Actions CI to run the Ruff lint check on every push and pull request

## Testing
- ruff check .


------
https://chatgpt.com/codex/tasks/task_e_68d2b0c3ebb48332b09a565e8e7c9e3b