### PR TITLE
Add validation and error handling to user routes

### DIFF
--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -1,0 +1,13 @@
+"""A minimal subset of the Marshmallow API used for request validation.
+
+This lightweight implementation provides the pieces required by the
+application's request schemas without pulling in the full dependency.
+It mirrors the interfaces for ``Schema``, ``ValidationError`` and the
+``fields`` module that our code relies on.
+"""
+
+from .exceptions import ValidationError
+from . import fields
+from .schema import Schema
+
+__all__ = ['Schema', 'ValidationError', 'fields']

--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -1,0 +1,8 @@
+class ValidationError(Exception):
+    """Replicates the core behaviour of marshmallow.ValidationError."""
+
+    def __init__(self, messages):
+        if messages is None:
+            messages = {}
+        self.messages = messages
+        super().__init__(str(messages))

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .exceptions import ValidationError
+
+
+class Field:
+    def __init__(self, *, required: bool = False):
+        self.required = required
+
+    def deserialize(self, value: Any):
+        return value
+
+
+class Str(Field):
+    def deserialize(self, value: Any):
+        value = super().deserialize(value)
+        if not isinstance(value, str):
+            raise ValidationError('Not a valid string.')
+        return value
+
+
+_EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+class Email(Str):
+    def deserialize(self, value: Any):
+        value = super().deserialize(value)
+        if not _EMAIL_PATTERN.match(value):
+            raise ValidationError('Not a valid email address.')
+        return value

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .exceptions import ValidationError
+from .fields import Field
+
+
+class SchemaMeta(type):
+    def __new__(mcls, name, bases, attrs):
+        declared_fields: Dict[str, Field] = {}
+        for base in reversed(bases):
+            base_fields = getattr(base, '_declared_fields', None)
+            if base_fields:
+                declared_fields.update(base_fields)
+
+        fields_for_class = {}
+        for key, value in list(attrs.items()):
+            if isinstance(value, Field):
+                fields_for_class[key] = value
+                attrs.pop(key)
+
+        declared_fields.update(fields_for_class)
+        attrs['_declared_fields'] = declared_fields
+        return super().__new__(mcls, name, bases, attrs)
+
+
+class Schema(metaclass=SchemaMeta):
+    def load(self, data: Any, partial: bool = False):
+        if not isinstance(data, dict):
+            raise ValidationError({'_schema': ['Invalid input type.']})
+
+        errors: Dict[str, Any] = {}
+        result: Dict[str, Any] = {}
+
+        for field_name, field in self._declared_fields.items():
+            if field_name not in data:
+                if field.required and not partial:
+                    errors.setdefault(field_name, []).append('Missing data for required field.')
+                continue
+
+            try:
+                result[field_name] = field.deserialize(data[field_name])
+            except ValidationError as err:
+                message = err.messages
+                if isinstance(message, list):
+                    errors[field_name] = message
+                else:
+                    errors.setdefault(field_name, []).append(message)
+
+        if errors:
+            raise ValidationError(errors)
+
+        for field_name in data.keys():
+            if field_name in self._declared_fields:
+                continue
+            # Preserve whitelisted fields only; unknowns are ignored.
+            pass
+
+        return result

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -1,35 +1,82 @@
 from flask import Blueprint, jsonify, request
+from marshmallow import Schema, ValidationError, fields
+from sqlalchemy.exc import IntegrityError
+
 from src.models.user import User, db
 
+
 user_bp = Blueprint('user', __name__)
+
+
+class UserSchema(Schema):
+    username = fields.Str(required=True)
+    email = fields.Email(required=True)
+
+
+user_schema = UserSchema()
+
 
 @user_bp.route('/users', methods=['GET'])
 def get_users():
     users = User.query.all()
     return jsonify([user.to_dict() for user in users])
 
+
 @user_bp.route('/users', methods=['POST'])
 def create_user():
-    
-    data = request.json
+    payload = request.get_json(silent=True)
+    if payload is None or not isinstance(payload, dict):
+        return jsonify({'errors': {'_schema': ['Invalid or missing JSON payload.']}}), 400
+
+    try:
+        data = user_schema.load(payload)
+    except ValidationError as err:
+        return jsonify({'errors': err.messages}), 400
+
     user = User(username=data['username'], email=data['email'])
     db.session.add(user)
-    db.session.commit()
+
+    try:
+        db.session.commit()
+    except IntegrityError as err:
+        db.session.rollback()
+        return _handle_integrity_error(err)
+
     return jsonify(user.to_dict()), 201
+
 
 @user_bp.route('/users/<int:user_id>', methods=['GET'])
 def get_user(user_id):
     user = User.query.get_or_404(user_id)
     return jsonify(user.to_dict())
 
+
 @user_bp.route('/users/<int:user_id>', methods=['PUT'])
 def update_user(user_id):
     user = User.query.get_or_404(user_id)
-    data = request.json
-    user.username = data.get('username', user.username)
-    user.email = data.get('email', user.email)
-    db.session.commit()
+    payload = request.get_json(silent=True)
+    if payload is None or not isinstance(payload, dict):
+        return jsonify({'errors': {'_schema': ['Invalid or missing JSON payload.']}}), 400
+
+    try:
+        data = user_schema.load(payload, partial=True)
+    except ValidationError as err:
+        return jsonify({'errors': err.messages}), 400
+
+    if not data:
+        return jsonify({'errors': {'_schema': ['No valid fields were provided for update.']}}), 400
+
+    for key, value in data.items():
+        setattr(user, key, value)
+
+    try:
+        db.session.commit()
+    except IntegrityError as err:
+        db.session.rollback()
+        return _handle_integrity_error(err)
+
     return jsonify(user.to_dict())
+
 
 @user_bp.route('/users/<int:user_id>', methods=['DELETE'])
 def delete_user(user_id):
@@ -37,3 +84,15 @@ def delete_user(user_id):
     db.session.delete(user)
     db.session.commit()
     return '', 204
+
+
+def _handle_integrity_error(error: IntegrityError):
+    message = str(getattr(error, 'orig', error)).lower()
+    errors = {}
+    if 'email' in message:
+        errors['email'] = ['Email already exists.']
+    if 'username' in message:
+        errors.setdefault('username', []).append('Username already exists.')
+    if not errors:
+        errors['_schema'] = ['Unique constraint violated.']
+    return jsonify({'errors': errors}), 409

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_user_routes.py
+++ b/tests/test_user_routes.py
@@ -1,0 +1,68 @@
+import unittest
+
+from flask import Flask
+
+from src.models.user import db
+from src.routes.user import user_bp
+
+
+class UserRouteTests(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+        self.app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+        db.init_app(self.app)
+
+        with self.app.app_context():
+            db.create_all()
+
+        self.app.register_blueprint(user_bp, url_prefix='/api')
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_create_user_requires_valid_payload(self):
+        response = self.client.post('/api/users', json={'email': 'not-an-email'})
+        self.assertEqual(response.status_code, 400)
+        data = response.get_json()
+        self.assertIn('username', data['errors'])
+        self.assertIn('email', data['errors'])
+
+    def test_create_user_rejects_duplicate_email(self):
+        create_response = self.client.post(
+            '/api/users',
+            json={'username': 'alice', 'email': 'alice@example.com'},
+        )
+        self.assertEqual(create_response.status_code, 201)
+
+        duplicate_response = self.client.post(
+            '/api/users',
+            json={'username': 'bob', 'email': 'alice@example.com'},
+        )
+        self.assertEqual(duplicate_response.status_code, 409)
+        duplicate_data = duplicate_response.get_json()
+        self.assertIn('email', duplicate_data['errors'])
+
+    def test_partial_update_allows_updating_subset_of_fields(self):
+        create_response = self.client.post(
+            '/api/users',
+            json={'username': 'charlie', 'email': 'charlie@example.com'},
+        )
+        user_id = create_response.get_json()['id']
+
+        update_response = self.client.put(
+            f'/api/users/{user_id}',
+            json={'email': 'charlie.new@example.com'},
+        )
+
+        self.assertEqual(update_response.status_code, 200)
+        updated_user = update_response.get_json()
+        self.assertEqual(updated_user['username'], 'charlie')
+        self.assertEqual(updated_user['email'], 'charlie.new@example.com')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a lightweight marshmallow-compatible validation layer for request schemas
- validate POST and PUT /users payloads and handle integrity errors gracefully
- cover malformed payloads, duplicate emails, and partial updates with unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2b09c63cc83328c229ac8e0d95bf7