### PR TITLE
Fix Docker build to include vendored marshmallow package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src/ ./src/
+COPY marshmallow/ ./marshmallow/
 
 EXPOSE 5001
 


### PR DESCRIPTION
## Summary
- copy the vendored `marshmallow` package into the Docker image so Flask routes can import it during deployment

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2b2b1e86083328b6918dbd754dbdd