### PR TITLE
Add route tests and CI workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = .git,__pycache__,.venv,venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8 pytest
+
+      - name: Run flake8
+        run: flake8
+
+      - name: Run pytest
+        run: pytest

--- a/src/routes/crypto.py
+++ b/src/routes/crypto.py
@@ -1,7 +1,6 @@
 from flask import Blueprint, jsonify, request
 import requests
 import os
-import time
 from datetime import datetime
 import logging
 from src.services.browsercat_client import browsercat_client

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite package for the MCP liquidation map application."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,74 @@
+"""Shared pytest fixtures for the test suite."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Iterator
+
+import pytest
+from flask import Flask
+from sqlalchemy.orm import Session
+
+from src.config import Config
+from src.models.user import db
+from src.routes.crypto import crypto_bp
+from src.routes.user import user_bp
+
+
+@pytest.fixture(scope="session")
+def app() -> Iterator[Flask]:
+    """Provide a configured Flask application for the test session."""
+    db_fd, db_path = tempfile.mkstemp()
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI=f"sqlite:///{db_path}",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+
+    app.register_blueprint(user_bp, url_prefix="/api")
+    app.register_blueprint(crypto_bp, url_prefix="/api")
+
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+    os.close(db_fd)
+    os.unlink(db_path)
+
+
+@pytest.fixture(scope="session")
+def _db(app):  # noqa: PT004
+    """Expose the SQLAlchemy database instance for tests."""
+    return db
+
+
+@pytest.fixture()
+def client(app):
+    """Return a Flask test client for HTTP endpoint validation."""
+    return app.test_client()
+
+
+@pytest.fixture()
+def db_session(app) -> Iterator[Session]:
+    """Provide a clean database session for each test case."""
+    with app.app_context():
+        yield db.session
+        db.session.rollback()
+        for table in reversed(db.metadata.sorted_tables):
+            db.session.execute(table.delete())
+        db.session.commit()
+        db.session.remove()
+
+
+@pytest.fixture(autouse=True)
+def _clear_simulated_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Ensure tests run without leaked simulation environment overrides."""
+    monkeypatch.delenv("ENABLE_SIMULATED_HEATMAP", raising=False)
+    yield

--- a/tests/test_crypto_routes.py
+++ b/tests/test_crypto_routes.py
@@ -1,0 +1,122 @@
+"""Tests for the cryptocurrency API routes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from src.routes import crypto
+
+
+class _DummyResponse:
+    """Lightweight HTTP response stub for mocking ``requests`` calls."""
+
+    def __init__(self, status_code: int, payload: Dict[str, Any]):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+@pytest.mark.usefixtures("db_session")
+class TestGetCryptoPrice:
+    """Unit tests for the ``/api/get_crypto_price`` endpoint."""
+
+    def test_returns_formatted_price_for_valid_symbol(self, client, monkeypatch):
+        """Endpoint should return a 200 with the formatted USD price."""
+        fake_payload = {"bitcoin": {"usd": 12345.6789}}
+        monkeypatch.setattr(
+            crypto.requests,
+            "get",
+            lambda url, timeout=10: _DummyResponse(200, fake_payload),
+        )
+
+        response = client.get("/api/get_crypto_price", query_string={"symbol": "btc"})
+
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body == {"price": "$12,345.68", "symbol": "BTC"}
+
+    def test_missing_symbol_returns_validation_error(self, client):
+        """A request without a symbol should respond with HTTP 400."""
+        response = client.get("/api/get_crypto_price")
+
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "Symbol parameter is required"
+
+
+@pytest.mark.usefixtures("db_session")
+class TestCaptureHeatmap:
+    """Unit tests for the ``/api/capture_heatmap`` endpoint."""
+
+    def test_returns_success_payload_when_browsercat_succeeds(self, client, monkeypatch):
+        """BrowserCat success should return the screenshot path payload."""
+        monkeypatch.setattr(
+            crypto.browsercat_client,
+            "capture_coinglass_heatmap",
+            lambda symbol, time_period: {"screenshot_path": "/tmp/success.png"},
+        )
+
+        response = client.post(
+            "/api/capture_heatmap",
+            json={"symbol": "eth", "time_period": "24 hour"},
+        )
+
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["image_path"] == "/tmp/success.png"
+        assert body["symbol"] == "ETH"
+        assert body["time_period"] == "24 hour"
+
+    def test_returns_simulated_fallback_when_browsercat_reports_error(
+        self, client, monkeypatch
+    ):
+        """A BrowserCat error should trigger a fallback when allowed."""
+        monkeypatch.setattr(
+            crypto.browsercat_client,
+            "capture_coinglass_heatmap",
+            lambda symbol, time_period: {"error": "service unavailable"},
+        )
+
+        response = client.post(
+            "/api/capture_heatmap",
+            json={
+                "symbol": "BTC",
+                "time_period": "24 hour",
+                "allow_simulated": True,
+            },
+        )
+
+        assert response.status_code == 502
+        body = response.get_json()
+        assert body["error"] == "Failed to capture heatmap via BrowserCat."
+        assert body["browsercat_error"] == "service unavailable"
+        assert body["fallback_provided"] is True
+        assert body["fallback"]["simulated"] is True
+        assert body["fallback"]["symbol"] == "BTC"
+
+    def test_handles_browsercat_exception_without_fallback(self, client, monkeypatch):
+        """An unexpected BrowserCat exception should be surfaced cleanly."""
+
+        def _raise_error(symbol: str, time_period: str) -> Dict[str, Any]:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            crypto.browsercat_client,
+            "capture_coinglass_heatmap",
+            _raise_error,
+        )
+
+        response = client.get(
+            "/api/capture_heatmap",
+            query_string={"symbol": "BTC", "time_period": "24 hour"},
+        )
+
+        assert response.status_code == 503
+        body = response.get_json()
+        assert body["error"] == "BrowserCat client error while capturing heatmap."
+        assert body["browsercat_error"] == "boom"
+        assert body["fallback_provided"] is False
+        assert "fallback" not in body


### PR DESCRIPTION
## Summary
- add pytest coverage for the crypto pricing and heatmap endpoints including BrowserCat error handling
- introduce shared Flask app and database fixtures to support future CRUD validation tests
- configure GitHub Actions to run flake8 and pytest with a repository-specific flake8 configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2b10a84248332985547d161ea848e