### PR TITLE
Load Flask configuration from Config object

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -40,7 +40,7 @@ def configure_logging():
 configure_logging()
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
-app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
+app.config.from_object(Config)
 
 
 app.register_blueprint(user_bp, url_prefix="/api")


### PR DESCRIPTION
## Summary
- load the Flask app configuration from the shared Config object so the secret key comes from configuration

## Testing
- `python -m pytest tests/test_logging_config.py` *(fails: SyntaxError in src/routes/crypto.py:157 due to unmatched parenthesis during import)*

------
https://chatgpt.com/codex/tasks/task_e_68d79d5ca044833296290613fcf716b6