### PR TITLE
Update documentation for example blueprint and migrations

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -23,7 +23,15 @@ This guide provides instructions for deploying the Crypto Heatmap MCP Server in 
    python src/main.py
    ```
 
-4. **Test the endpoints**:
+4. **(Optional) Generate initial database migration**:
+   The default SQLite database is empty. Run these commands only if you intend to persist data (for example, when using the example `/api/users` routes):
+   ```bash
+   flask --app src.main db init        # run once if migrations/ does not exist yet
+   flask --app src.main db migrate -m "initial schema"
+   flask --app src.main db upgrade
+   ```
+
+5. **Test the endpoints**:
    ```bash
    curl "http://localhost:5001/api/health"
    curl "http://localhost:5001/api/get_crypto_price?symbol=BTC"

--- a/README.md
+++ b/README.md
@@ -122,10 +122,13 @@ Use the `allow_simulated=true` query parameter (or set the `ENABLE_SIMULATED_HEA
 
 
 
-5. **Apply database migrations** (run this before starting the server to create/update the schema):
+5. **(Optional) Prepare the database schema**. The bundled SQLite database starts empty and does not include migrations out of the box. You only need to run migrations after you create them:
    ```bash
+   flask --app src.main db init        # run once if migrations/ does not exist yet
+   flask --app src.main db migrate -m "initial schema"
    flask --app src.main db upgrade
    ```
+   Skip these commands if you do not plan to use the database features yet.
 
 6. **Run the server**:
    ```bash
@@ -133,6 +136,10 @@ Use the `allow_simulated=true` query parameter (or set the `ENABLE_SIMULATED_HEA
    ```
 
 The server will start on `http://localhost:5001`
+
+### Example User Blueprint
+
+The `/api/users` endpoints provided by `src/routes/user.py` are registered by default as an example blueprint that demonstrates database usage. Remove the line that imports `user_bp` and the corresponding `app.register_blueprint(user_bp, url_prefix="/api")` call in `src/main.py` if you want to disable these routes.
 
 ## Logging
 
@@ -167,7 +174,7 @@ mcp-liquidation-map/
 │   ├── main.py                     # Main Flask application
 │   ├── routes/
 │   │   ├── crypto.py              # Cryptocurrency API endpoints
-│   │   └── user.py                # Template user routes (unused)
+│   │   └── user.py                # Example user routes blueprint (registered by default)
 │   ├── services/
 │   │   └── browsercat_client.py   # BrowserCat MCP integration
 │   ├── models/                    # Database models (unused)


### PR DESCRIPTION
## Summary
- explain that the README now clarifies the optional example user blueprint and how to disable it
- replace the blanket migration step with optional instructions for generating and applying an initial migration
- mirror the new migration guidance in the deployment guide for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79d5d96308332b172482bf909df6b