### PR TITLE
Fix BrowserCat error logging formatting in crypto route

### DIFF
--- a/src/routes/crypto.py
+++ b/src/routes/crypto.py
@@ -156,7 +156,7 @@ def capture_heatmap():
             if "error" in heatmap_result:
                 _get_logger().error(
                     f"BrowserCat heatmap capture failed: {heatmap_result['error']}"
-
+                )
                 status_code = heatmap_result.get('status_code')
                 logger.error(
                     "BrowserCat heatmap capture failed (status=%s): %s",


### PR DESCRIPTION
## Summary
- close the BrowserCat error log call before executing follow-up logic in capture_heatmap

## Testing
- pytest tests/test_capture_heatmap.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e645a91c8332b69971a991b6691f