### PR TITLE
Handle BrowserCat path fallback

### DIFF
--- a/src/routes/crypto.py
+++ b/src/routes/crypto.py
@@ -147,7 +147,11 @@ def capture_heatmap():
 
         allow_simulated_override = _parse_bool(allow_simulated_param)
         env_allow_simulated = _parse_bool(os.getenv('ENABLE_SIMULATED_HEATMAP'))
-        allow_simulated = allow_simulated_override if allow_simulated_override is not None else bool(env_allow_simulated)
+        allow_simulated = (
+            allow_simulated_override
+            if allow_simulated_override is not None
+            else bool(env_allow_simulated)
+        )
 
         # Use BrowserCat MCP client to capture heatmap
         try:
@@ -156,6 +160,7 @@ def capture_heatmap():
             if "error" in heatmap_result:
                 _get_logger().error(
                     f"BrowserCat heatmap capture failed: {heatmap_result['error']}"
+                )
 
                 status_code = heatmap_result.get('status_code')
                 logger.error(
@@ -185,8 +190,14 @@ def capture_heatmap():
                 return jsonify(response_payload), 502
             else:
                 # Success - return actual screenshot path
+                image_path = (
+                    heatmap_result.get('screenshot_path')
+                    or heatmap_result.get('path')
+                    or '/tmp/heatmap.png'
+                )
+
                 return jsonify({
-                    'image_path': heatmap_result.get('screenshot_path', '/tmp/heatmap.png'),
+                    'image_path': image_path,
                     'symbol': symbol,
                     'time_period': time_period,
                     'browsercat_result': heatmap_result

--- a/tests/test_capture_heatmap.py
+++ b/tests/test_capture_heatmap.py
@@ -32,6 +32,19 @@ class CaptureHeatmapRouteTests(unittest.TestCase):
         mock_capture.assert_called_once_with('BTC', '24 hour')
 
     @patch('src.routes.crypto.browsercat_client.capture_coinglass_heatmap')
+    def test_capture_heatmap_uses_path_when_screenshot_missing(self, mock_capture):
+        mock_capture.return_value = {'path': '/tmp/fallback.png'}
+
+        response = self.client.get('/api/capture_heatmap?symbol=BTC&time_period=24%20hour')
+
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(data['image_path'], '/tmp/fallback.png')
+        self.assertEqual(data['symbol'], 'BTC')
+        self.assertEqual(data['time_period'], '24 hour')
+        mock_capture.assert_called_once_with('BTC', '24 hour')
+
+    @patch('src.routes.crypto.browsercat_client.capture_coinglass_heatmap')
     def test_capture_heatmap_browsercat_failure_without_fallback(self, mock_capture):
         mock_capture.return_value = {'error': 'Request failed with status 401'}
 


### PR DESCRIPTION
## Summary
- prefer BrowserCat heatmap response `screenshot_path` while gracefully falling back to `path` before using a default
- update capture heatmap tests to ensure the API echoes the client `path` when no screenshot is provided

## Testing
- pytest tests/test_capture_heatmap.py tests/test_browsercat_client.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e6495da083329da555a2236a4a91