### PR TITLE
Handle invalid JSON payloads in crypto routes

### DIFF
--- a/src/routes/crypto.py
+++ b/src/routes/crypto.py
@@ -1,12 +1,10 @@
-from flask import Blueprint, jsonify, request, current_app
-import requests
-
 import logging
 import os
 from datetime import datetime
 
 import requests
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, current_app
+from werkzeug.exceptions import BadRequest
 from src.services.browsercat_client import browsercat_client
 
 _TRUTHY_STRINGS = {'1', 'true', 'yes', 'on'}
@@ -36,6 +34,7 @@ def get_crypto_price():
     - price (string): Formatted price (e.g., "$30,000.00")
     - error (string, optional): Error message if operation fails
     """
+    symbol = None
     try:
         if request.method == 'GET':
             symbol = request.args.get('symbol')
@@ -78,9 +77,23 @@ def get_crypto_price():
         else:
             return jsonify({'error': f'Failed to fetch price for {symbol}'}), 500
             
+    except BadRequest as json_error:
+        symbol_for_log = symbol or 'unknown'
+        _get_logger().warning(
+            "Invalid JSON payload while fetching price for symbol=%s: %s",
+            symbol_for_log,
+            json_error,
+        )
+        return jsonify({'error': 'Invalid JSON payload.'}), 400
     except Exception as e:
-        _get_logger().error(f"Error fetching {symbol} price: {e}")
-        return jsonify({'error': str(e)}), 500
+        symbol_for_log = symbol or 'unknown'
+        _get_logger().error(
+            "Error fetching price for symbol=%s: %s",
+            symbol_for_log,
+            e,
+            exc_info=True,
+        )
+        return jsonify({'error': 'Internal server error.'}), 500
 
 def _parse_bool(value):
     """Parse common truthy/falsey values to booleans."""
@@ -127,6 +140,8 @@ def capture_heatmap():
     - image_path (string): Path to captured image file
     - error (string, optional): Error message if operation fails
     """
+    symbol = None
+    time_period = None
     try:
         if request.method == 'GET':
             symbol = request.args.get('symbol', 'BTC')
@@ -147,7 +162,11 @@ def capture_heatmap():
 
         allow_simulated_override = _parse_bool(allow_simulated_param)
         env_allow_simulated = _parse_bool(os.getenv('ENABLE_SIMULATED_HEATMAP'))
-        allow_simulated = allow_simulated_override if allow_simulated_override is not None else bool(env_allow_simulated)
+        allow_simulated = (
+            allow_simulated_override
+            if allow_simulated_override is not None
+            else bool(env_allow_simulated)
+        )
 
         # Use BrowserCat MCP client to capture heatmap
         try:
@@ -155,7 +174,9 @@ def capture_heatmap():
 
             if "error" in heatmap_result:
                 _get_logger().error(
-                    f"BrowserCat heatmap capture failed: {heatmap_result['error']}"
+                    "BrowserCat heatmap capture failed: %s",
+                    heatmap_result['error'],
+                )
 
                 status_code = heatmap_result.get('status_code')
                 logger.error(
@@ -193,7 +214,15 @@ def capture_heatmap():
                 })
                 
         except Exception as browsercat_error:
-            _get_logger().error(f"BrowserCat client error: {browsercat_error}")
+            symbol_for_log = symbol or 'unknown'
+            time_period_for_log = time_period or 'unknown'
+            _get_logger().error(
+                "BrowserCat client error for symbol=%s, time_period=%s: %s",
+                symbol_for_log,
+                time_period_for_log,
+                browsercat_error,
+                exc_info=True,
+            )
             response_payload = {
                 'error': 'BrowserCat client error while capturing heatmap.',
                 'browsercat_error': str(browsercat_error),
@@ -209,9 +238,27 @@ def capture_heatmap():
 
             return jsonify(response_payload), 503
         
+    except BadRequest as json_error:
+        symbol_for_log = symbol or 'unknown'
+        time_period_for_log = time_period or 'unknown'
+        _get_logger().warning(
+            "Invalid JSON payload for capture_heatmap (symbol=%s, time_period=%s): %s",
+            symbol_for_log,
+            time_period_for_log,
+            json_error,
+        )
+        return jsonify({'error': 'Invalid JSON payload.'}), 400
     except Exception as e:
-        _get_logger().error(f"Error capturing heatmap: {e}")
-        return jsonify({'error': str(e)}), 500
+        symbol_for_log = symbol or 'unknown'
+        time_period_for_log = time_period or 'unknown'
+        _get_logger().error(
+            "Error capturing heatmap for symbol=%s, time_period=%s: %s",
+            symbol_for_log,
+            time_period_for_log,
+            e,
+            exc_info=True,
+        )
+        return jsonify({'error': 'Internal server error.'}), 500
 
 @crypto_bp.route('/health', methods=['GET'])
 def health_check():

--- a/tests/test_capture_heatmap.py
+++ b/tests/test_capture_heatmap.py
@@ -62,6 +62,17 @@ class CaptureHeatmapRouteTests(unittest.TestCase):
         self.assertTrue(fallback['simulated'])
         self.assertTrue(fallback['image_path'].startswith('/tmp/sol_liquidation_heatmap_'))
 
+    def test_capture_heatmap_invalid_json_returns_400(self):
+        response = self.client.post(
+            '/api/capture_heatmap',
+            data='this-is-not-json',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.get_json()
+        self.assertEqual(data['error'], 'Invalid JSON payload.')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- guard crypto price and heatmap routes with fallback symbols and sanitized error payloads for unexpected exceptions
- enhance BrowserCat exception logging to include safe fallback values
- add a regression test ensuring invalid JSON payloads return a 400 response

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7e64826d48332a1b72c1ea5397f1d