### PR TITLE
Document marshmallow shim in deployment docs

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -77,11 +77,17 @@ This guide provides instructions for deploying the Crypto Heatmap MCP Server in 
    RUN pip install --no-cache-dir -r requirements.txt
 
    COPY src/ ./src/
+   COPY marshmallow/ ./marshmallow/
 
    EXPOSE 5001
 
    CMD ["python", "src/main.py"]
    ```
+
+   The extra `marshmallow/` copy step is required because this project ships a
+   lightweight shim that patches a compatibility gap with older Marshmallow
+   consumers. Without copying it into the container image, the runtime import
+   hook is missing and requests that depend on the shim will fail.
 
 2. **Build and run**:
    ```bash

--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ For production deployment, consider:
 3. **Configure reverse proxy** (e.g., Nginx)
 4. **Enable HTTPS** for secure communication
 5. **Set up monitoring** and logging
+6. **Copy the custom Marshmallow shim when containerizing** so the
+   `marshmallow/` compatibility layer is available at runtime (see the Docker
+   example in `DEPLOYMENT_GUIDE.md`).
 
 ## License
 


### PR DESCRIPTION
## Summary
- update the Docker deployment example to copy the marshmallow shim directory
- explain why the marshmallow shim must be included in container images
- remind README deployment readers to include the shim when containerizing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e916ff80833280909f831adcfa84