### PR TITLE
Clean up crypto route imports

### DIFF
--- a/src/routes/crypto.py
+++ b/src/routes/crypto.py
@@ -3,8 +3,9 @@ import os
 from datetime import datetime
 
 import requests
-from flask import Blueprint, jsonify, request, current_app
+from flask import Blueprint, current_app, jsonify, request
 from werkzeug.exceptions import BadRequest
+
 from src.services.browsercat_client import browsercat_client
 
 _TRUTHY_STRINGS = {'1', 'true', 'yes', 'on'}


### PR DESCRIPTION
## Summary
- reorder the crypto route imports into a single canonical block

## Testing
- ruff check --fix src/routes/crypto.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e91a1e008332b88f59370cf73c5c