### PR TITLE
Gate user API behind opt-in flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,14 @@ Use the `allow_simulated=true` query parameter (or set the `ENABLE_SIMULATED_HEA
 
 
 
-5. **(Optional) Prepare the database schema**. The bundled SQLite database starts empty and does not include migrations out of the box. You only need to run migrations after you create them:
-   ```bash
-   flask --app src.main db init        # run once if migrations/ does not exist yet
-   flask --app src.main db migrate -m "initial schema"
-   flask --app src.main db upgrade
-   ```
+5. **(Optional) Prepare the database schema for the user API**. The optional `/api/users` endpoints are disabled by default but require tables when enabled:
+   - **SQLite (default)**: No manual work is required—the app calls `db.create_all()` on startup when `ENABLE_USER_API` is truthy. The SQLite file lives at `src/database/app.db`.
+   - **Other databases**: Run your migrations before enabling the flag:
+     ```bash
+     flask --app src.main db init        # run once if migrations/ does not exist yet
+     flask --app src.main db migrate -m "initial schema"
+     flask --app src.main db upgrade
+     ```
    Skip these commands if you do not plan to use the database features yet.
 
 6. **Run the server**:
@@ -145,7 +147,13 @@ The server will start on `http://localhost:5001`
 
 ### Example User Blueprint
 
-The `/api/users` endpoints provided by `src/routes/user.py` are registered by default as an example blueprint that demonstrates database usage. Remove the line that imports `user_bp` and the corresponding `app.register_blueprint(user_bp, url_prefix="/api")` call in `src/main.py` if you want to disable these routes.
+The `/api/users` endpoints provided by `src/routes/user.py` demonstrate SQLAlchemy usage and are **opt-in**. To enable them:
+
+1. Prepare the database schema (see [Installation Step 5](#installation-and-setup)).
+   - SQLite users can rely on the automatic `db.create_all()` call; other databases must run migrations first.
+2. Set `ENABLE_USER_API=1` (or any truthy value) in your environment before starting the server.
+
+When disabled, the blueprint is not registered and the landing page hides the related UI controls. A new `/api/features` endpoint exposes the feature flag for client-side checks.
 
 ## Logging
 
@@ -180,7 +188,7 @@ mcp-liquidation-map/
 │   ├── main.py                     # Main Flask application
 │   ├── routes/
 │   │   ├── crypto.py              # Cryptocurrency API endpoints
-│   │   └── user.py                # Example user routes blueprint (registered by default)
+│   │   └── user.py                # Example user routes blueprint (enable with ENABLE_USER_API)
 │   ├── services/
 │   │   └── browsercat_client.py   # BrowserCat MCP integration
 │   ├── models/                    # Database models (unused)
@@ -200,6 +208,7 @@ is not defined.
 - `BROWSERCAT_BASE_URL`: Override the BrowserCat MCP base URL (`https://server.smithery.ai/@dmaznest/browsercat-mcp-server`).
 - `DATABASE_URI`: Database connection string (`sqlite:///src/database/app.db`).
 - `DEBUG`: Enable Flask debug mode when set to a truthy value (disabled by default).
+- `ENABLE_USER_API`: Opt into registering the example `/api/users` routes (disabled by default).
 - `SECRET_KEY`: Flask secret key used for session signing. Required when `DEBUG`
   is false; omitted values cause startup to fail in production. When `DEBUG` is
   true the app falls back to a development-only default (`dev-secret-key`).

--- a/src/config.py
+++ b/src/config.py
@@ -32,6 +32,7 @@ class Config:
         "DATABASE_URI", f"sqlite:///{DEFAULT_SQLITE_PATH}"
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    ENABLE_USER_API = _str_to_bool(os.getenv("ENABLE_USER_API"), default=False)
 
 
 def get_config() -> Config:

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,13 @@
+import logging
 import os
 import sys
-import logging
+
 # DON'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from flask import Flask, send_from_directory
+from flask import Flask, jsonify, send_from_directory
 from flask_migrate import Migrate
+from sqlalchemy import inspect
 
 from src.config import Config
 from src.models.user import db
@@ -43,11 +45,40 @@ app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'sta
 app.config.from_object(Config)
 
 
-app.register_blueprint(user_bp, url_prefix="/api")
-app.register_blueprint(crypto_bp, url_prefix="/api")
-
 db.init_app(app)
 migrate = Migrate(app, db)
+
+
+def _ensure_user_schema(application: Flask) -> None:
+    """Ensure the user schema exists when the user API is enabled."""
+
+    database_uri = application.config.get("SQLALCHEMY_DATABASE_URI", "")
+    with application.app_context():
+        if database_uri.startswith("sqlite:///"):
+            sqlite_path = database_uri.replace("sqlite:///", "", 1)
+            sqlite_dir = os.path.dirname(sqlite_path)
+            if sqlite_dir:
+                os.makedirs(sqlite_dir, exist_ok=True)
+            db.create_all()
+            return
+
+        inspector = inspect(db.engine)
+        if not inspector.has_table("user"):
+            raise RuntimeError(
+                "ENABLE_USER_API is set but the database schema is missing. "
+                "Run your migrations (e.g. `flask --app src.main db upgrade`)."
+            )
+
+
+if app.config.get("ENABLE_USER_API"):
+    _ensure_user_schema(app)
+    app.register_blueprint(user_bp, url_prefix="/api")
+else:
+    logging.getLogger(__name__).info(
+        "User API disabled. Set ENABLE_USER_API=1 to opt in."
+    )
+
+app.register_blueprint(crypto_bp, url_prefix="/api")
 
 @app.route('/', defaults={'path': ''})
 @app.route('/<path:path>')
@@ -64,6 +95,13 @@ def serve(path):
             return send_from_directory(static_folder_path, 'index.html')
         else:
             return "index.html not found", 404
+
+
+@app.route("/api/features", methods=["GET"])
+def feature_flags():
+    """Expose frontend feature flags."""
+
+    return jsonify({"userApiEnabled": bool(app.config.get("ENABLE_USER_API"))})
 
 
 if __name__ == "__main__":

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -16,55 +16,67 @@
     </style>
 </head>
 <body>
-    <h1>User API Test</h1>
+    <h1>Crypto Heatmap MCP Server</h1>
+    <p>Use the controls below to explore available API features.</p>
 
-    <!-- Get All Users -->
-    <div class="section">
-        <h2>Get All Users (GET /users)</h2>
-        <button onclick="getUsers()">Get Users</button>
-        <pre id="get-users-result"></pre>
+    <div id="user-api-disabled" class="section" role="status">
+        <h2>Example User API Disabled</h2>
+        <p id="user-api-disabled-message">
+            The optional <code>/api/users</code> endpoints are not enabled. Set the
+            <code>ENABLE_USER_API</code> environment variable to a truthy value and
+            configure the database to opt in.
+        </p>
     </div>
 
-    <!-- Create User -->
-    <div class="section">
-        <h2>Create User (POST /users)</h2>
-        <label for="create-username">Username:</label>
-        <input type="text" id="create-username" name="username"><br>
-        <label for="create-email">Email:</label>
-        <input type="email" id="create-email" name="email"><br>
-        <button onclick="createUser()">Create User</button>
-        <pre id="create-user-result"></pre>
-    </div>
+    <div id="user-api-container" hidden>
+        <!-- Get All Users -->
+        <div class="section">
+            <h2>Get All Users (GET /users)</h2>
+            <button onclick="getUsers()">Get Users</button>
+            <pre id="get-users-result"></pre>
+        </div>
 
-    <!-- Get Single User -->
-    <div class="section">
-        <h2>Get Single User (GET /users/&lt;id&gt;)</h2>
-        <label for="get-user-id">User ID:</label>
-        <input type="number" id="get-user-id" name="user_id"><br>
-        <button onclick="getUser()">Get User</button>
-        <pre id="get-user-result"></pre>
-    </div>
+        <!-- Create User -->
+        <div class="section">
+            <h2>Create User (POST /users)</h2>
+            <label for="create-username">Username:</label>
+            <input type="text" id="create-username" name="username"><br>
+            <label for="create-email">Email:</label>
+            <input type="email" id="create-email" name="email"><br>
+            <button onclick="createUser()">Create User</button>
+            <pre id="create-user-result"></pre>
+        </div>
 
-    <!-- Update User -->
-    <div class="section">
-        <h2>Update User (PUT /users/&lt;id&gt;)</h2>
-        <label for="update-user-id">User ID:</label>
-        <input type="number" id="update-user-id" name="user_id"><br>
-        <label for="update-username">New Username:</label>
-        <input type="text" id="update-username" name="username"><br>
-        <label for="update-email">New Email:</label>
-        <input type="email" id="update-email" name="email"><br>
-        <button onclick="updateUser()">Update User</button>
-        <pre id="update-user-result"></pre>
-    </div>
+        <!-- Get Single User -->
+        <div class="section">
+            <h2>Get Single User (GET /users/&lt;id&gt;)</h2>
+            <label for="get-user-id">User ID:</label>
+            <input type="number" id="get-user-id" name="user_id"><br>
+            <button onclick="getUser()">Get User</button>
+            <pre id="get-user-result"></pre>
+        </div>
 
-    <!-- Delete User -->
-    <div class="section">
-        <h2>Delete User (DELETE /users/&lt;id&gt;)</h2>
-        <label for="delete-user-id">User ID:</label>
-        <input type="number" id="delete-user-id" name="user_id"><br>
-        <button onclick="deleteUser()">Delete User</button>
-        <pre id="delete-user-result"></pre>
+        <!-- Update User -->
+        <div class="section">
+            <h2>Update User (PUT /users/&lt;id&gt;)</h2>
+            <label for="update-user-id">User ID:</label>
+            <input type="number" id="update-user-id" name="user_id"><br>
+            <label for="update-username">New Username:</label>
+            <input type="text" id="update-username" name="username"><br>
+            <label for="update-email">New Email:</label>
+            <input type="email" id="update-email" name="email"><br>
+            <button onclick="updateUser()">Update User</button>
+            <pre id="update-user-result"></pre>
+        </div>
+
+        <!-- Delete User -->
+        <div class="section">
+            <h2>Delete User (DELETE /users/&lt;id&gt;)</h2>
+            <label for="delete-user-id">User ID:</label>
+            <input type="number" id="delete-user-id" name="user_id"><br>
+            <button onclick="deleteUser()">Delete User</button>
+            <pre id="delete-user-result"></pre>
+        </div>
     </div>
 
     <script>
@@ -202,6 +214,29 @@
                 displayError(resultElementId, error);
             }
         }
+
+        async function initialiseFeatureFlags() {
+            const container = document.getElementById('user-api-container');
+            const disabledSection = document.getElementById('user-api-disabled');
+            const disabledMessage = document.getElementById('user-api-disabled-message');
+
+            try {
+                const response = await fetch('/api/features');
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                if (data.userApiEnabled) {
+                    container.hidden = false;
+                    disabledSection.hidden = true;
+                }
+            } catch (error) {
+                disabledMessage.textContent = `Unable to determine feature availability: ${error.message}`;
+            }
+        }
+
+        window.addEventListener('DOMContentLoaded', initialiseFeatureFlags);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add an ENABLE_USER_API configuration flag that gates the user blueprint and ensures the schema exists when enabled
- expose a lightweight feature flag endpoint and hide the user API controls on the landing page unless the flag is active
- document the opt-in process for the example user blueprint and update configuration guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7e912cbf083329649dc39a7b91e92