### PR TITLE
Remove sys.path hacks and improve import guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ node_modules/
 package-lock.json
 .env
 /venv
+.egg-info/
 .git
 src/database/app.db

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -18,9 +18,16 @@ This guide provides instructions for deploying the Crypto Heatmap MCP Server in 
    ```
    Use whatever virtual environment tooling fits your workflow if you already have one configured.
 
+   Install the project in editable mode if you want its imports to be available globally while you develop locally:
+
+   ```bash
+   pip install -r requirements.txt
+   pip install -e .
+   ```
+
 3. **Run the server**:
    ```bash
-   python src/main.py
+   python -m src.main
    ```
 
 4. **(Optional) Generate initial database migration**:
@@ -80,7 +87,7 @@ This guide provides instructions for deploying the Crypto Heatmap MCP Server in 
 
    EXPOSE 5001
 
-   CMD ["python", "src/main.py"]
+   CMD ["python", "-m", "src.main"]
    ```
 
 2. **Build and run**:
@@ -211,7 +218,7 @@ Environment=BROWSERCAT_API_KEY=your-api-key-here
 Environment=SECRET_KEY=change-me
 Environment=DATABASE_URI=postgresql+psycopg://user:pass@host:5432/dbname
 Environment=BROWSERCAT_BASE_URL=https://server.smithery.ai/@dmaznest/browsercat-mcp-server
-ExecStart=/home/ubuntu/mcp-liquidation-map/.venv/bin/python src/main.py
+ExecStart=/home/ubuntu/mcp-liquidation-map/.venv/bin/python -m src.main
 Restart=always
 RestartSec=10
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ Use the `allow_simulated=true` query parameter (or set the `ENABLE_SIMULATED_HEA
    pip install -r requirements-dev.txt
    ```
 
+   If you prefer to make the project importable from anywhere on your machine, install it in editable mode after the
+   dependencies are in place:
+
+   ```bash
+   pip install -e .
+   ```
+
 4. **Configure environment variables** (see [Configuration](#configuration) for details).
 
 
@@ -138,7 +145,7 @@ Use the `allow_simulated=true` query parameter (or set the `ENABLE_SIMULATED_HEA
 
 6. **Run the server**:
    ```bash
-   python src/main.py
+   python -m src.main
    ```
 
 The server will start on `http://localhost:5001`
@@ -157,7 +164,7 @@ You can customize the log level by setting the `APP_LOG_LEVEL` environment varia
 
 ```bash
 export APP_LOG_LEVEL=DEBUG
-python src/main.py
+python -m src.main
 ```
 
 Any valid Python logging level name (e.g., `ERROR`, `WARNING`) is accepted.
@@ -280,7 +287,7 @@ the `DEBUG` environment variable before starting the server:
 
 ```bash
 export DEBUG=1
-python src/main.py
+python -m src.main
 ```
 
 This enables automatic reloading on code changes and detailed error messages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mcp-liquidation-map"
+version = "0.1.0"
+description = "Crypto liquidation heatmap MCP server"
+readme = "README.md"
+requires-python = ">=3.11"
+
+[tool.setuptools]
+packages = ["src", "marshmallow"]

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,5 @@
 import os
-import sys
 import logging
-# DON'T CHANGE THIS !!!
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from flask import Flask, send_from_directory
 from flask_migrate import Migrate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,0 @@
-import os
-import sys
-
-
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_browsercat_client.py
+++ b/tests/test_browsercat_client.py
@@ -1,9 +1,6 @@
 import json
 import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.services.browsercat_client import BrowserCatMCPClient
 


### PR DESCRIPTION
## Summary
- remove manual sys.path manipulation from the Flask entry point and tests so imports use normal resolution
- add packaging metadata for editable installs and update README/deployment docs to highlight `python -m src.main`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7e9184f488332bc98cd9f0961527d