### PR TITLE
Fix CI workflow to install dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Run Ruff
         run: ruff check .


### PR DESCRIPTION
## Summary
- ensure the CI workflow installs both runtime and development requirements so Ruff is available for linting

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7e9df37f083328ed30febc35edbf8