### PR TITLE
Add Smithery deployment configuration and MCP server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,59 @@
+[build-system]
+requires = ["uv_build>=0.8.15,<0.9.0"]
+build-backend = "uv_build"
+
+[project]
+name = "mcp-liquidation-map"
+version = "0.1.0"
+description = "Crypto liquidation heatmap MCP server with Flask and Smithery integration."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "alembic==1.14.0",
+    "blinker==1.9.0",
+    "certifi==2025.7.14",
+    "charset-normalizer==3.4.2",
+    "click==8.2.1",
+    "Flask==3.1.1",
+    "Flask-Migrate==4.0.7",
+    "Flask-SQLAlchemy==3.1.1",
+    "greenlet==3.2.3",
+    "idna==3.10",
+    "itsdangerous==2.2.0",
+    "Jinja2==3.1.6",
+    "Mako==1.3.7",
+    "MarkupSafe==3.0.2",
+    "requests==2.32.4",
+    "SQLAlchemy==2.0.41",
+    "urllib3==2.5.0",
+    "Werkzeug==3.1.3",
+    "mcp>=1.15.0",
+    "smithery>=0.4.2",
+    "pydantic>=2.8.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff==0.7.1",
+    "pytest>=8.3.4",
+]
+
+[project.scripts]
+dev = "smithery.cli.dev:main"
+playground = "smithery.cli.playground:main"
+
+[tool.setuptools.packages.find]
+include = ["src*", "marshmallow*"]
+
+[tool.setuptools.package-data]
+"src" = [
+    "static/*",
+    "static/**/*",
+    "database/*.db",
+]
+
+[tool.smithery]
+server = "src.server:create_server"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,1 @@
+runtime: "python"

--- a/src/routes/crypto.py
+++ b/src/routes/crypto.py
@@ -1,6 +1,8 @@
 import logging
 import os
+from dataclasses import dataclass
 from datetime import datetime
+from typing import Optional
 
 import requests
 from flask import Blueprint, current_app, jsonify, request
@@ -11,9 +13,175 @@ from src.services.browsercat_client import browsercat_client
 _TRUTHY_STRINGS = {'1', 'true', 'yes', 'on'}
 _FALSY_STRINGS = {'0', 'false', 'no', 'off'}
 
+_COINGECKO_SYMBOL_MAP = {
+    'BTC': 'bitcoin',
+    'ETH': 'ethereum',
+    'BNB': 'binancecoin',
+    'ADA': 'cardano',
+    'SOL': 'solana',
+    'XRP': 'ripple',
+    'DOT': 'polkadot',
+    'DOGE': 'dogecoin',
+    'AVAX': 'avalanche-2',
+    'MATIC': 'matic-network',
+}
+
+_VALID_TIMEFRAMES = ["12 hour", "24 hour", "1 month", "3 month"]
+
 crypto_bp = Blueprint('crypto', __name__)
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ServiceResult:
+    """Container for service responses shared by HTTP and MCP surfaces."""
+
+    payload: dict
+    status_code: int = 200
+
+
+def _resolve_coin_id(symbol: str) -> str:
+    """Map a symbol to CoinGecko's identifier when available."""
+
+    return _COINGECKO_SYMBOL_MAP.get(symbol, symbol.lower())
+
+
+def build_crypto_price_result(
+    symbol: Optional[str],
+    log: Optional[logging.Logger] = None,
+) -> ServiceResult:
+    """Return the API payload for the crypto price endpoint."""
+
+    log = log or logger
+
+    if not symbol:
+        return ServiceResult({'error': 'Symbol parameter is required', 'status_code': 400}, 400)
+
+    symbol = symbol.upper()
+    coin_id = _resolve_coin_id(symbol)
+    url = f"https://api.coingecko.com/api/v3/simple/price?ids={coin_id}&vs_currencies=usd"
+
+    response = requests.get(url, timeout=10)
+    if response.status_code != 200:
+        log.warning('Failed to fetch price for %s (status=%s)', symbol, response.status_code)
+        return ServiceResult({
+            'error': f'Failed to fetch price for {symbol}',
+            'status_code': 500,
+        }, 500)
+
+    data = response.json()
+    price = data.get(coin_id, {}).get('usd')
+    if price is None:
+        return ServiceResult({'error': f'Price not found for {symbol}', 'status_code': 404}, 404)
+
+    formatted_price = f"${price:,.2f}"
+    return ServiceResult({'price': formatted_price, 'symbol': symbol})
+
+
+def _resolve_allow_simulated(allow_simulated_override: Optional[bool]) -> bool:
+    """Resolve whether simulated payloads are permitted."""
+
+    if allow_simulated_override is not None:
+        return allow_simulated_override
+
+    env_allow_simulated = _parse_bool(os.getenv('ENABLE_SIMULATED_HEATMAP'))
+    if env_allow_simulated is not None:
+        return env_allow_simulated
+
+    return True
+
+
+def build_heatmap_result(
+    symbol: str,
+    time_period: str,
+    allow_simulated_override: Optional[bool] = None,
+    log: Optional[logging.Logger] = None,
+) -> ServiceResult:
+    """Return the payload for the liquidation heatmap capture endpoint."""
+
+    log = log or logger
+
+    symbol = symbol.upper()
+    if time_period not in _VALID_TIMEFRAMES:
+        return ServiceResult({
+            'error': f'Invalid timeframe. Use: {", ".join(_VALID_TIMEFRAMES)}',
+            'status_code': 400,
+        }, 400)
+
+    allow_simulated = _resolve_allow_simulated(allow_simulated_override)
+
+    try:
+        heatmap_result = browsercat_client.capture_coinglass_heatmap(symbol, time_period)
+    except Exception as browsercat_error:
+        log.error(
+            "BrowserCat client error for symbol=%s, time_period=%s: %s",
+            symbol,
+            time_period,
+            browsercat_error,
+            exc_info=True,
+        )
+        response_payload = {
+            'error': 'BrowserCat client error while capturing heatmap.',
+            'browsercat_error': str(browsercat_error),
+            'browsercat_status_code': getattr(browsercat_error, 'status_code', None),
+            'symbol': symbol,
+            'time_period': time_period,
+            'fallback_provided': False,
+        }
+
+        if allow_simulated:
+            response_payload['fallback'] = _build_simulated_payload(symbol, time_period)
+            response_payload['fallback_provided'] = True
+
+        response_payload.setdefault('status_code', 503)
+        return ServiceResult(response_payload, 503)
+
+    if 'error' in heatmap_result:
+        status_code = heatmap_result.get('status_code')
+        log.error('BrowserCat heatmap capture failed: %s', heatmap_result['error'])
+        logger.error(
+            'BrowserCat heatmap capture failed (status=%s): %s',
+            status_code,
+            heatmap_result['error'],
+        )
+
+        response_payload = {
+            'error': 'Failed to capture heatmap via BrowserCat.',
+            'browsercat_error': heatmap_result['error'],
+            'browsercat_status_code': status_code,
+            'symbol': symbol,
+            'time_period': time_period,
+            'fallback_provided': False,
+        }
+
+        if 'response' in heatmap_result:
+            response_payload['browsercat_response'] = heatmap_result['response']
+
+        if 'response_text' in heatmap_result:
+            response_payload['browsercat_response_text'] = heatmap_result['response_text']
+
+        if allow_simulated:
+            response_payload['fallback'] = _build_simulated_payload(symbol, time_period)
+            response_payload['fallback_provided'] = True
+
+        response_payload.setdefault('status_code', 502)
+        return ServiceResult(response_payload, 502)
+
+    image_path = (
+        heatmap_result.get('screenshot_path')
+        or heatmap_result.get('path')
+        or '/tmp/heatmap.png'
+    )
+
+    payload = {
+        'image_path': image_path,
+        'symbol': symbol,
+        'time_period': time_period,
+        'browsercat_result': heatmap_result,
+    }
+
+    return ServiceResult(payload)
 
 
 def _get_logger():
@@ -42,42 +210,10 @@ def get_crypto_price():
         else:  # POST
             data = request.get_json()
             symbol = data.get('symbol') if data else None
-        
-        if not symbol:
-            return jsonify({'error': 'Symbol parameter is required'}), 400
-        
-        symbol = symbol.upper()
-        
-        # Map common symbols to CoinGecko IDs
-        symbol_map = {
-            'BTC': 'bitcoin',
-            'ETH': 'ethereum',
-            'BNB': 'binancecoin',
-            'ADA': 'cardano',
-            'SOL': 'solana',
-            'XRP': 'ripple',
-            'DOT': 'polkadot',
-            'DOGE': 'dogecoin',
-            'AVAX': 'avalanche-2',
-            'MATIC': 'matic-network'
-        }
-        
-        coin_id = symbol_map.get(symbol, symbol.lower())
-        url = f"https://api.coingecko.com/api/v3/simple/price?ids={coin_id}&vs_currencies=usd"
-        
-        response = requests.get(url, timeout=10)
-        
-        if response.status_code == 200:
-            data = response.json()
-            price = data.get(coin_id, {}).get('usd')
-            if price:
-                formatted_price = f"${price:,.2f}"
-                return jsonify({'price': formatted_price, 'symbol': symbol})
-            else:
-                return jsonify({'error': f'Price not found for {symbol}'}), 404
-        else:
-            return jsonify({'error': f'Failed to fetch price for {symbol}'}), 500
-            
+
+        result = build_crypto_price_result(symbol, log=_get_logger())
+        return jsonify(result.payload), result.status_code
+
     except BadRequest as json_error:
         symbol_for_log = symbol or 'unknown'
         _get_logger().warning(
@@ -132,11 +268,11 @@ def _build_simulated_payload(symbol: str, time_period: str):
 def capture_heatmap():
     """
     Capture Coinglass liquidation heatmap
-    
+
     Parameters:
     - symbol (string): Cryptocurrency symbol (e.g., "BTC", "ETH")
     - time_period (string, optional): Time period ("12 hour", "24 hour", "1 month", "3 month")
-    
+
     Returns:
     - image_path (string): Path to captured image file
     - error (string, optional): Error message if operation fails
@@ -154,100 +290,15 @@ def capture_heatmap():
             time_period = data.get('time_period', '24 hour') if data else '24 hour'
             allow_simulated_param = data.get('allow_simulated') if data else None
 
-        symbol = symbol.upper()
-
-        # Validate time period
-        valid_timeframes = ["12 hour", "24 hour", "1 month", "3 month"]
-        if time_period not in valid_timeframes:
-            return jsonify({'error': f'Invalid timeframe. Use: {", ".join(valid_timeframes)}'}), 400
-
         allow_simulated_override = _parse_bool(allow_simulated_param)
-        env_allow_simulated = _parse_bool(os.getenv('ENABLE_SIMULATED_HEATMAP'))
+        result = build_heatmap_result(
+            symbol,
+            time_period,
+            allow_simulated_override,
+            log=_get_logger(),
+        )
+        return jsonify(result.payload), result.status_code
 
-        if allow_simulated_override is not None:
-            allow_simulated = allow_simulated_override
-        elif env_allow_simulated is not None:
-            allow_simulated = env_allow_simulated
-        else:
-            allow_simulated = True
-
-        # Use BrowserCat MCP client to capture heatmap
-        try:
-            heatmap_result = browsercat_client.capture_coinglass_heatmap(symbol, time_period)
-
-            if "error" in heatmap_result:
-                _get_logger().error(
-                    "BrowserCat heatmap capture failed: %s",
-                    heatmap_result['error'],
-
-                )
-
-                status_code = heatmap_result.get('status_code')
-                logger.error(
-                    "BrowserCat heatmap capture failed (status=%s): %s",
-                    status_code,
-                    heatmap_result['error'],
-                )
-                response_payload = {
-                    'error': 'Failed to capture heatmap via BrowserCat.',
-                    'browsercat_error': heatmap_result['error'],
-                    'browsercat_status_code': status_code,
-                    'symbol': symbol,
-                    'time_period': time_period,
-                    'fallback_provided': False
-                }
-
-                if 'response' in heatmap_result:
-                    response_payload['browsercat_response'] = heatmap_result['response']
-
-                if 'response_text' in heatmap_result:
-                    response_payload['browsercat_response_text'] = heatmap_result['response_text']
-
-                if allow_simulated:
-                    response_payload['fallback'] = _build_simulated_payload(symbol, time_period)
-                    response_payload['fallback_provided'] = True
-
-                return jsonify(response_payload), 502
-            else:
-                # Success - return actual screenshot path
-                image_path = (
-                    heatmap_result.get('screenshot_path')
-                    or heatmap_result.get('path')
-                    or '/tmp/heatmap.png'
-                )
-
-                return jsonify({
-                    'image_path': image_path,
-                    'symbol': symbol,
-                    'time_period': time_period,
-                    'browsercat_result': heatmap_result
-                })
-                
-        except Exception as browsercat_error:
-            symbol_for_log = symbol or 'unknown'
-            time_period_for_log = time_period or 'unknown'
-            _get_logger().error(
-                "BrowserCat client error for symbol=%s, time_period=%s: %s",
-                symbol_for_log,
-                time_period_for_log,
-                browsercat_error,
-                exc_info=True,
-            )
-            response_payload = {
-                'error': 'BrowserCat client error while capturing heatmap.',
-                'browsercat_error': str(browsercat_error),
-                'browsercat_status_code': getattr(browsercat_error, 'status_code', None),
-                'symbol': symbol,
-                'time_period': time_period,
-                'fallback_provided': False
-            }
-
-            if allow_simulated:
-                response_payload['fallback'] = _build_simulated_payload(symbol, time_period)
-                response_payload['fallback_provided'] = True
-
-            return jsonify(response_payload), 503
-        
     except BadRequest as json_error:
         symbol_for_log = symbol or 'unknown'
         time_period_for_log = time_period or 'unknown'

--- a/src/server.py
+++ b/src/server.py
@@ -1,0 +1,78 @@
+"""Smithery FastMCP server entrypoint."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from mcp.server.fastmcp import Context, FastMCP
+from pydantic import BaseModel, Field
+from smithery.decorators import smithery
+
+from src.routes.crypto import build_crypto_price_result, build_heatmap_result, ServiceResult
+
+
+class SessionConfig(BaseModel):
+    """Session-level configuration exposed to Smithery clients."""
+
+    default_time_period: str = Field(
+        "24 hour",
+        description="Default liquidation heatmap window when none is provided.",
+    )
+    allow_simulated: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Override simulated fallback behaviour. "
+            "`true` always attaches simulated payloads, `false` disables them, "
+            "and `null` defers to environment configuration."
+        ),
+    )
+
+
+@smithery.server(config_schema=SessionConfig)
+def create_server() -> FastMCP:
+    """Create and configure the FastMCP server used by Smithery deployments."""
+
+    server = FastMCP(name="Crypto Heatmap MCP Server")
+
+    @server.tool()
+    def get_crypto_price(symbol: str, ctx: Context) -> dict:
+        """Fetch the latest USD price for a cryptocurrency symbol."""
+
+        result: ServiceResult = build_crypto_price_result(symbol)
+        if result.status_code >= 400:
+            message = result.payload.get('error') or f'Failed to fetch price for {symbol}'
+            raise RuntimeError(message)
+        return result.payload
+
+    @server.tool()
+    def capture_heatmap(
+        symbol: str,
+        ctx: Context,
+        time_period: Optional[str] = None,
+        allow_simulated: Optional[bool] = None,
+    ) -> dict:
+        """Capture a liquidation heatmap for the requested symbol."""
+
+        session_config: SessionConfig = ctx.session_config or SessionConfig()
+        effective_time_period = time_period or session_config.default_time_period
+        effective_allow_simulated = (
+            allow_simulated if allow_simulated is not None else session_config.allow_simulated
+        )
+
+        result = build_heatmap_result(
+            symbol,
+            effective_time_period,
+            effective_allow_simulated,
+        )
+
+        if result.status_code >= 500:
+            message = result.payload.get('error') or 'BrowserCat client error while capturing heatmap.'
+            raise RuntimeError(message)
+
+        if result.status_code >= 400:
+            # Return the structured payload (which may include a simulated fallback)
+            return result.payload
+
+        return result.payload
+
+    return server


### PR DESCRIPTION
## Summary
- add a pyproject with Smithery configuration, dependencies, and pytest settings
- introduce a smithery.yaml runtime declaration for Python deployments
- expose shared crypto helpers and a FastMCP create_server entrypoint for Smithery

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7ec23d7508332b2004e10fc9c0202