### PR TITLE
Specify Smithery Python 3.12 runtime

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,1 +1,1 @@
-runtime: "python"
+runtime: "python-3.12"


### PR DESCRIPTION
## Summary
- set the Smithery runtime to python-3.12 so builds use the same interpreter version required by the project

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7f4e8512483329da8ada38173e8e3