### PR TITLE
Fix Python build backend configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["uv_build>=0.8.15,<0.9.0"]
-build-backend = "uv_build"
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-liquidation-map"


### PR DESCRIPTION
## Summary
- replace the uv_build backend with setuptools.build_meta in pyproject.toml to avoid missing build tool failures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7f635c18c8332a98cbdb3e2264c02