### PR TITLE
Fix Smithery entrypoint for src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ playground = "smithery.cli.playground:main"
 where = ["src", "."]
 include = ["mcp_liquidation_map*", "marshmallow*"]
 
+[tool.setuptools]
+py-modules = ["smithery_entry"]
+
 [tool.setuptools.package-data]
 "src" = [
     "static/*",
@@ -54,7 +57,7 @@ include = ["mcp_liquidation_map*", "marshmallow*"]
 ]
 
 [tool.smithery]
-server = "mcp_liquidation_map.server:create_server"
+server = "smithery_entry:create_server"
 
 [tool.pytest.ini_options]
 pythonpath = [".", "src"]

--- a/smithery_entry.py
+++ b/smithery_entry.py
@@ -1,0 +1,26 @@
+"""Smithery entrypoint that makes the src layout importable."""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _ensure_src_on_path() -> None:
+    project_root = Path(__file__).resolve().parent
+    src_dir = project_root / "src"
+    if src_dir.is_dir():
+        src_path = str(src_dir)
+        if src_path not in sys.path:
+            sys.path.insert(0, src_path)
+
+
+def create_server(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to the real server factory used by Smithery."""
+    try:
+        server_module = importlib.import_module("mcp_liquidation_map.server")
+    except ModuleNotFoundError:
+        _ensure_src_on_path()
+        server_module = importlib.import_module("mcp_liquidation_map.server")
+    return getattr(server_module, "create_server")(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add a Smithery entrypoint shim that injects the `src` folder into `sys.path` before importing the Flask server
- register the shim module in `pyproject.toml` and point Smithery to it so local runs succeed without installing the package

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d7f8769fbc833289ceef941f2189cc