### PR TITLE
Fix setuptools package data configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,15 +42,16 @@ dev = [
 dev = "smithery.cli.dev:main"
 playground = "smithery.cli.playground:main"
 
+[tool.setuptools]
+py-modules = ["smithery_entry"]
+include-package-data = true
+
 [tool.setuptools.packages.find]
 where = ["src", "."]
 include = ["mcp_liquidation_map*", "marshmallow*"]
 
-[tool.setuptools]
-py-modules = ["smithery_entry"]
-
 [tool.setuptools.package-data]
-"src" = [
+"mcp_liquidation_map" = [
     "static/*",
     "static/**/*",
     "database/*.db",


### PR DESCRIPTION
## Summary
- ensure package data is associated with the actual mcp_liquidation_map package
- enable include-package-data to ship static assets from the wheel

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7fd1bf9d88332b7a9e1d08cf4d84b