### PR TITLE
Guard app startup against missing SECRET_KEY in production

### DIFF
--- a/src/mcp_liquidation_map/main.py
+++ b/src/mcp_liquidation_map/main.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import logging
 
 import sys
 
@@ -11,7 +10,7 @@ from flask import Flask, jsonify, send_from_directory
 from flask_migrate import Migrate
 from sqlalchemy import inspect
 
-from mcp_liquidation_map.config import Config
+from mcp_liquidation_map.config import get_config
 from mcp_liquidation_map.models.user import db
 from mcp_liquidation_map.routes.crypto import crypto_bp
 from mcp_liquidation_map.routes.user import user_bp
@@ -44,7 +43,7 @@ def configure_logging():
 configure_logging()
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
-app.config.from_object(Config)
+app.config.from_object(get_config())
 
 
 db.init_app(app)

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -9,6 +9,9 @@ from flask import Flask
 from mcp_liquidation_map.routes.crypto import crypto_bp
 
 
+os.environ.setdefault('SECRET_KEY', 'test-secret-key')
+
+
 class CryptoBlueprintLoggingTests(unittest.TestCase):
     def test_capture_heatmap_logs_to_current_app_logger(self):
         app = Flask(__name__)
@@ -48,6 +51,12 @@ class ConfigureLoggingTests(unittest.TestCase):
         self.original_handlers = list(self.root_logger.handlers)
         self.original_level = self.root_logger.level
         self.original_app_log_level = os.environ.get('APP_LOG_LEVEL')
+        self.original_secret_key = os.environ.get('SECRET_KEY')
+        if self.original_secret_key is None:
+            os.environ['SECRET_KEY'] = 'test-secret-key'
+        import mcp_liquidation_map.config as config_module
+        importlib.reload(config_module)
+        self.config_module = config_module
         self.main_module = importlib.import_module('mcp_liquidation_map.main')
 
     def tearDown(self):
@@ -62,6 +71,12 @@ class ConfigureLoggingTests(unittest.TestCase):
         else:
             os.environ['APP_LOG_LEVEL'] = self.original_app_log_level
 
+        if self.original_secret_key is None:
+            os.environ.pop('SECRET_KEY', None)
+        else:
+            os.environ['SECRET_KEY'] = self.original_secret_key
+
+        importlib.reload(self.config_module)
         importlib.reload(self.main_module)
 
     def test_configure_logging_respects_existing_handlers(self):


### PR DESCRIPTION
## Summary
- initialize the Flask app with get_config() so startup fails without SECRET_KEY when DEBUG is off
- seed SECRET_KEY within the logging configuration tests and reload the config module to satisfy the stricter guard

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbfc9bc2f083329d1ee1713f317eeb