### PR TITLE
Update documentation for Python 3.12 prerequisites

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -76,7 +76,7 @@ This guide provides instructions for deploying the Crypto Heatmap MCP Server in 
 
 1. **Create Dockerfile**:
    ```dockerfile
-   FROM python:3.11-slim
+   FROM python:3.12-slim
 
    WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Simulated payloads are returned by default whenever BrowserCat fails (including 
 
 ### Prerequisites
 
-- Python 3.11+
+- Python 3.12+
 - Virtual environment support
 
 ### Installation Steps
@@ -336,7 +336,7 @@ For issues and questions:
 
 ## Changelog
 
-### v1.0.0
+### v0.1.0
 - Initial release
 - Cryptocurrency price fetching via CoinGecko API
 - BrowserCat MCP integration for heatmap capture


### PR DESCRIPTION
## Summary
- align README prerequisites with the project's Python >=3.12 requirement
- correct the changelog to reference version 0.1.0, matching package metadata
- update the deployment guide Docker example to use the Python 3.12 base image

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dbfca166dc8332abcecf97cc74223e