### PR TITLE
Use Python 3.12 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- update the CI workflow to run against Python 3.12 so it matches the documented prerequisites

## Testing
- pip install -r requirements.txt
- pip install -r requirements-dev.txt
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc0ace8adc83329024bff8505267e6