### PR TITLE
Fix documentation module references

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -27,15 +27,15 @@ This guide provides instructions for deploying the Crypto Heatmap MCP Server in 
 
 3. **Run the server**:
    ```bash
-   python -m src.main
+   python -m mcp_liquidation_map.main
    ```
 
 4. **(Optional) Generate initial database migration**:
    The default SQLite database is empty. Run these commands only if you intend to persist data (for example, when using the example `/api/users` routes):
    ```bash
-   flask --app src.main db init        # run once if migrations/ does not exist yet
-   flask --app src.main db migrate -m "initial schema"
-   flask --app src.main db upgrade
+   flask --app mcp_liquidation_map.main db init        # run once if migrations/ does not exist yet
+   flask --app mcp_liquidation_map.main db migrate -m "initial schema"
+   flask --app mcp_liquidation_map.main db upgrade
    ```
 
 5. **Test the endpoints**:
@@ -69,7 +69,7 @@ This guide provides instructions for deploying the Crypto Heatmap MCP Server in 
 
 3. **Run with Gunicorn**:
    ```bash
-   gunicorn -c gunicorn.conf.py src.main:app
+   gunicorn -c gunicorn.conf.py mcp_liquidation_map.main:app
    ```
 
 #### Option 2: Using Docker
@@ -88,7 +88,7 @@ This guide provides instructions for deploying the Crypto Heatmap MCP Server in 
 
    EXPOSE 5001
 
-   CMD ["python", "-m", "src.main"]
+   CMD ["python", "-m", "mcp_liquidation_map.main"]
    ```
 
    The extra `marshmallow/` copy step is required because this project ships a
@@ -115,7 +115,7 @@ This guide provides instructions for deploying the Crypto Heatmap MCP Server in 
   simulated payloads are provided by default.
 - `BROWSERCAT_BASE_URL`: Override the BrowserCat MCP server URL. Default:
   `https://server.smithery.ai/@dmaznest/browsercat-mcp-server`.
-- `DATABASE_URI`: Database connection string. Defaults to the bundled SQLite database at `sqlite:///src/database/app.db`.
+- `DATABASE_URI`: Database connection string. Defaults to the bundled SQLite database at `sqlite:///src/mcp_liquidation_map/database/app.db`.
 - `FLASK_ENV`: Set to `production` for production deployment.
 - `SECRET_KEY`: Flask secret key. When `DEBUG` is false this value is required
   and the app will abort on startup if it is missing. A `dev-secret-key` default
@@ -226,7 +226,7 @@ Environment=BROWSERCAT_API_KEY=your-api-key-here
 Environment=SECRET_KEY=change-me
 Environment=DATABASE_URI=postgresql+psycopg://user:pass@host:5432/dbname
 Environment=BROWSERCAT_BASE_URL=https://server.smithery.ai/@dmaznest/browsercat-mcp-server
-ExecStart=/home/ubuntu/mcp-liquidation-map/.venv/bin/python -m src.main
+ExecStart=/home/ubuntu/mcp-liquidation-map/.venv/bin/python -m mcp_liquidation_map.main
 Restart=always
 RestartSec=10
 
@@ -357,7 +357,7 @@ The server includes input validation, but consider additional measures:
 2. **Permission denied**:
    ```bash
    # Ensure proper file permissions
-   chmod +x src/main.py
+   chmod +x src/mcp_liquidation_map/main.py
    ```
 
 3. **Module not found**:
@@ -376,7 +376,7 @@ The server includes input validation, but consider additional measures:
 
 Enable debug mode for troubleshooting:
 ```python
-# In src/main.py
+# In src/mcp_liquidation_map/main.py
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5001, debug=True)
 ```

--- a/README.md
+++ b/README.md
@@ -142,25 +142,25 @@ Simulated payloads are returned by default whenever BrowserCat fails (including 
 
 
 5. **(Optional) Prepare the database schema for the user API**. The optional `/api/users` endpoints are disabled by default but require tables when enabled:
-   - **SQLite (default)**: No manual work is required—the app calls `db.create_all()` on startup when `ENABLE_USER_API` is truthy. The SQLite file lives at `src/database/app.db`.
+   - **SQLite (default)**: No manual work is required—the app calls `db.create_all()` on startup when `ENABLE_USER_API` is truthy. The SQLite file lives at `src/mcp_liquidation_map/database/app.db`.
    - **Other databases**: Run your migrations before enabling the flag:
      ```bash
-     flask --app src.main db init        # run once if migrations/ does not exist yet
-     flask --app src.main db migrate -m "initial schema"
-     flask --app src.main db upgrade
+     flask --app mcp_liquidation_map.main db init        # run once if migrations/ does not exist yet
+     flask --app mcp_liquidation_map.main db migrate -m "initial schema"
+     flask --app mcp_liquidation_map.main db upgrade
      ```
    Skip these commands if you do not plan to use the database features yet.
 
 6. **Run the server**:
    ```bash
-   python -m src.main
+   python -m mcp_liquidation_map.main
    ```
 
 The server will start on `http://localhost:5001`
 
 ### Example User Blueprint
 
-The `/api/users` endpoints provided by `src/routes/user.py` demonstrate SQLAlchemy usage and are **opt-in**. To enable them:
+The `/api/users` endpoints provided by `src/mcp_liquidation_map/routes/user.py` demonstrate SQLAlchemy usage and are **opt-in**. To enable them:
 
 1. Prepare the database schema (see [Installation Step 5](#installation-and-setup)).
    - SQLite users can rely on the automatic `db.create_all()` call; other databases must run migrations first.
@@ -178,7 +178,7 @@ You can customize the log level by setting the `APP_LOG_LEVEL` environment varia
 
 ```bash
 export APP_LOG_LEVEL=DEBUG
-python -m src.main
+python -m mcp_liquidation_map.main
 ```
 
 Any valid Python logging level name (e.g., `ERROR`, `WARNING`) is accepted.
@@ -219,7 +219,7 @@ is not defined.
 
 - `BROWSERCAT_API_KEY`: BrowserCat API key for real heatmap captures (no default, simulated payloads used when unset). Get a free key at https://browsercat.xyz/mcp.
 - `BROWSERCAT_BASE_URL`: Override the BrowserCat MCP base URL (`https://server.smithery.ai/@dmaznest/browsercat-mcp-server`).
-- `DATABASE_URI`: Database connection string (`sqlite:///src/database/app.db`).
+- `DATABASE_URI`: Database connection string (`sqlite:///src/mcp_liquidation_map/database/app.db`).
 - `DEBUG`: Enable Flask debug mode when set to a truthy value (disabled by default).
 - `ENABLE_USER_API`: Opt into registering the example `/api/users` routes (disabled by default).
 - `SECRET_KEY`: Flask secret key used for session signing. Required when `DEBUG`
@@ -302,7 +302,7 @@ the `DEBUG` environment variable before starting the server:
 
 ```bash
 export DEBUG=1
-python -m src.main
+python -m mcp_liquidation_map.main
 ```
 
 This enables automatic reloading on code changes and detailed error messages.


### PR DESCRIPTION
## Summary
- update README instructions to reference the mcp_liquidation_map package paths
- correct deployment guide examples for gunicorn, docker, and systemd to use the proper module name
- fix documented SQLite and blueprint paths to reflect the current project layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0a213f748332adbdee71fe7c19d4