### PR TITLE
Add CI workflow for linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,11 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:
-  lint:
+  build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -18,16 +15,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Run Ruff
         run: ruff check .


### PR DESCRIPTION
## Summary
- add a CI workflow that runs on push and pull request events
- configure Python 3.12, install dependencies, and run Ruff and pytest

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc10bd205c8332bacbabd0d7cab2e4