### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,140 @@
 # Crypto Heatmap MCP Server
 
-A Smithery-compatible Model Context Protocol (MCP) server that provides cryptocurrency price fetching and Coinglass liquidation heatmap capture functionality. This server replicates the core functionality of the original Python script without Telegram notifications.
+A Smithery-compatible Model Context Protocol (MCP) server that delivers cryptocurrency market data and Coinglass liquidation heatmap captures over a simple REST API. The service mirrors the functionality of the original script while removing Telegram-specific logic and adding production-ready HTTP endpoints, health checks, and fallbacks.
 
-## Features
+## Table of Contents
+- [Key Features](#key-features)
+- [Architecture Overview](#architecture-overview)
+- [Quick Start](#quick-start)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Running the Server](#running-the-server)
+- [Configuration](#configuration)
+  - [Environment Variables](#environment-variables)
+  - [Smithery / BrowserCat Integration](#smithery--browsercat-integration)
+  - [Fallback Behaviour](#fallback-behaviour)
+- [API Reference](#api-reference)
+  - [Crypto Price](#1-get-cryptocurrency-price)
+  - [Heatmap Capture](#2-capture-liquidation-heatmap)
+  - [Health Check](#3-health-check)
+  - [Optional User API](#optional-user-api)
+- [Supported Assets](#supported-assets)
+- [Development Workflow](#development-workflow)
+  - [Testing](#testing)
+  - [Linting](#linting)
+  - [Database Migrations](#database-migrations)
+- [Deployment Notes](#deployment-notes)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+- [Changelog](#changelog)
+- [License](#license)
 
-- **Cryptocurrency Price Fetching**: Get real-time cryptocurrency prices using CoinGecko API
-- **Liquidation Heatmap Capture**: Capture Coinglass liquidation heatmaps using BrowserCat MCP integration
-- **RESTful API**: Clean HTTP endpoints for easy integration
-- **Error Handling**: Graceful fallback responses when external services are unavailable
-- **Health Monitoring**: Built-in health check endpoint
+## Key Features
 
-## API Endpoints
+- **Real-time pricing** – Fetch up-to-date cryptocurrency prices from the CoinGecko API.
+- **Automated heatmaps** – Capture Coinglass liquidation heatmaps using BrowserCat MCP automation tools.
+- **Resilient fallbacks** – Provide simulated heatmap payloads when BrowserCat is unavailable.
+- **HTTP-first design** – Expose endpoints that can be consumed by Smithery clients, scripts, or other services.
+- **Health monitoring** – Report service health with a lightweight `/api/health` endpoint.
+
+## Architecture Overview
+
+The application is a Flask service packaged as an MCP server. It orchestrates three key pieces:
+
+1. **CoinGecko price fetcher** – Simple HTTP calls to retrieve ticker data.
+2. **BrowserCat MCP client** – Automates browser interactions for heatmap screenshots.
+3. **Optional SQL-backed user API** – A CRUD example demonstrating database integration with SQLAlchemy and Marshmallow.
+
+All HTTP routes live under `/api/*` and are version-agnostic, keeping integration straightforward.
+
+## Quick Start
+
+### Prerequisites
+
+- Python **3.12 or later**
+- Optional: virtual environment tooling (`venv`, `virtualenv`, or `conda`)
+- (For heatmaps) BrowserCat MCP credentials
+- (For optional user API) SQLite or another SQLAlchemy-supported database
+
+### Installation
+
+```bash
+# Clone the repository and enter the project directory
+cd mcp-liquidation-map
+
+# (Recommended) create and activate a virtual environment
+python -m venv .venv
+source .venv/bin/activate
+
+# Install runtime and development dependencies
+pip install -r requirements.txt
+# or, for development extras
+pip install -r requirements-dev.txt
+```
+
+### Running the Server
+
+```bash
+# Export any configuration you need (see the table below)
+export DEBUG=1
+export SECRET_KEY="dev-secret-key"
+
+# Start the Flask app
+python -m mcp_liquidation_map.main
+```
+
+The service listens on `http://localhost:5001` by default. When running through Smithery (`smithery dev`), configuration is handled through `smithery.yaml`.
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `SECRET_KEY` | Yes (unless `DEBUG=1`) | – | Flask secret key; must be set in production. |
+| `DEBUG` | No | `0` | Enables Flask debug mode and auto reload. |
+| `APP_LOG_LEVEL` | No | `INFO` | Root logging level (`DEBUG`, `INFO`, etc.). |
+| `DATABASE_URI` | No | SQLite at `src/mcp_liquidation_map/database/app.db` | SQLAlchemy connection string for the optional user API. |
+| `ENABLE_USER_API` | No | `0` | Enable CRUD endpoints under `/api/users`. |
+| `USER_API_TOKEN` | Required when user API enabled | – | Bearer token required for all user API requests. |
+| `BROWSERCAT_API_KEY` | Recommended | – | Authentication for BrowserCat MCP. Without it, simulated heatmaps are returned. |
+| `BROWSERCAT_BASE_URL` | No | `https://server.smithery.ai/@dmaznest/browsercat-mcp-server` | Override BrowserCat endpoint. |
+| `BROWSERCAT_TIMEOUT` | No | `30` | Request timeout (seconds) for BrowserCat operations. |
+| `ENABLE_SIMULATED_HEATMAP` | No | `1` | `1`/`true` forces simulated heatmaps; `0` disables fallback. |
+
+### Smithery / BrowserCat Integration
+
+The service uses Smithery MCP to communicate with BrowserCat. The following tools are invoked:
+
+- `browsercat_navigate` – Navigate to the Coinglass page.
+- `browsercat_screenshot` – Capture the heatmap image.
+- `browsercat_click` – Interact with page filters (e.g., symbol/time period selectors).
+- `browsercat_evaluate` – Execute supporting JavaScript snippets.
+
+Override the BrowserCat server URL or timeouts using the environment variables above.
+
+### Fallback Behaviour
+
+If BrowserCat is unreachable (missing credentials, network outage, or 4xx/5xx responses), the server emits a simulated payload containing placeholder image information. Control this behaviour by:
+
+- Passing `allow_simulated=false` in the heatmap request, or
+- Exporting `ENABLE_SIMULATED_HEATMAP=false` to disable the fallback globally, or
+- Setting `allow_simulated=true`/`ENABLE_SIMULATED_HEATMAP=true` to force the simulated payload (useful for development).
+
+## API Reference
 
 ### 1. Get Cryptocurrency Price
 
-**Endpoint**: `/api/get_crypto_price`  
-**Methods**: GET, POST  
-**Parameters**:
-- `symbol` (string, required): Cryptocurrency symbol (e.g., "BTC", "ETH")
+- **Endpoint**: `GET /api/get_crypto_price`
+- **Query Parameters**:
+  - `symbol` (string, required) – Cryptocurrency symbol (e.g., `BTC`, `ETH`). Case-insensitive.
 
-**Example Request**:
+**Example**
+
 ```bash
 curl "http://localhost:5001/api/get_crypto_price?symbol=BTC"
 ```
 
-**Example Response**:
 ```json
 {
   "price": "$113,975.00",
@@ -34,19 +144,21 @@ curl "http://localhost:5001/api/get_crypto_price?symbol=BTC"
 
 ### 2. Capture Liquidation Heatmap
 
-**Endpoint**: `/api/capture_heatmap`  
-**Methods**: GET, POST  
-**Parameters**:
-- `symbol` (string, required): Cryptocurrency symbol (e.g., "BTC", "ETH")
-- `time_period` (string, optional, default: "24 hour"): Time period ("12 hour", "24 hour", "1 month", "3 month")
-- `allow_simulated` (boolean, optional): Override fallback behaviour. `false` disables the simulated payload, `true` forces it, and omitting the parameter defers to the `ENABLE_SIMULATED_HEATMAP` environment variable (which defaults to the simulated fallback being enabled).
+- **Endpoint**: `POST /api/capture_heatmap`
+- **Accepted Methods**: `GET` or `POST` (JSON body or query string)
+- **Parameters**:
+  - `symbol` (string, required) – Cryptocurrency symbol.
+  - `time_period` (string, optional) – One of `12 hour`, `24 hour`, `1 month`, or `3 month`. Defaults to `24 hour`.
+  - `allow_simulated` (boolean, optional) – Overrides the fallback behaviour described above.
 
-**Example Request**:
+**Example request**
+
 ```bash
 curl "http://localhost:5001/api/capture_heatmap?symbol=BTC&time_period=24%20hour"
 ```
 
-**Example Response**:
+**Successful response**
+
 ```json
 {
   "image_path": "/tmp/heatmap.png",
@@ -58,7 +170,7 @@ curl "http://localhost:5001/api/capture_heatmap?symbol=BTC&time_period=24%20hour
 }
 ```
 
-**Example BrowserCat Failure (HTTP 502)**:
+**Fallback response (HTTP 502)**
 
 ```json
 {
@@ -77,14 +189,10 @@ curl "http://localhost:5001/api/capture_heatmap?symbol=BTC&time_period=24%20hour
 }
 ```
 
-Simulated payloads are returned by default whenever BrowserCat fails (including when the API key is missing). To opt out, pass `allow_simulated=false` or set `ENABLE_SIMULATED_HEATMAP=false`. Use `allow_simulated=true` (or `ENABLE_SIMULATED_HEATMAP=true`) to explicitly force the fallback when needed for local development.
-
 ### 3. Health Check
 
-**Endpoint**: `/api/health`  
-**Method**: GET
+- **Endpoint**: `GET /api/health`
 
-**Example Response**:
 ```json
 {
   "status": "healthy",
@@ -92,266 +200,93 @@ Simulated payloads are returned by default whenever BrowserCat fails (including 
 }
 ```
 
-## Installation and Setup
+### Optional User API
 
-### Prerequisites
+When `ENABLE_USER_API=1`, CRUD endpoints for managing users become available under `/api/users`. Every request must include a bearer token that matches `USER_API_TOKEN`.
 
-- Python 3.12+
-- Virtual environment support
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/users` | List all users. |
+| `POST` | `/api/users` | Create a user (`username`, `email`). |
+| `GET` | `/api/users/<id>` | Retrieve a specific user. |
+| `PUT` | `/api/users/<id>` | Update a user (partial updates allowed). |
+| `DELETE` | `/api/users/<id>` | Remove a user. |
 
-### Installation Steps
+When using a database other than SQLite, ensure the schema exists by running migrations before enabling the API (see below).
 
-1. **Clone or extract the project**:
-   ```bash
-   cd mcp-liquidation-map
-   ```
+## Supported Assets
 
-2. **Create (optional) virtual environment**:
-   ```bash
-   python -m venv .venv
-   source .venv/bin/activate
-   ```
-   Use your preferred virtual environment tooling if you already have one configured.
+The service proxies CoinGecko and therefore supports any symbol CoinGecko recognises (BTC, ETH, BNB, ADA, SOL, XRP, DOT, DOGE, AVAX, MATIC, and many more). Unknown symbols return a descriptive 400 error.
 
-3. **Install dependencies**:
-   ```bash
-   pip install -r requirements.txt
-   ```
+## Development Workflow
 
-   To install optional developer tooling such as linting utilities, use the development requirements file:
+### Testing
 
-   ```bash
-   pip install -r requirements-dev.txt
-   ```
-
-   This adds local tooling like `pytest`, enabling the project's automated test suite via:
-
-   ```bash
-   pytest
-   ```
-
-   If you prefer to make the project importable from anywhere on your machine, install it in editable mode after the
-   dependencies are in place:
-
-   ```bash
-   pip install -e .
-   ```
-
-4. **Configure environment variables** (see [Configuration](#configuration) for details).
-
-
-
-5. **(Optional) Prepare the database schema for the user API**. The optional `/api/users` endpoints are disabled by default but require tables when enabled:
-   - **SQLite (default)**: No manual work is required—the app calls `db.create_all()` on startup when `ENABLE_USER_API` is truthy. The SQLite file lives at `src/mcp_liquidation_map/database/app.db`.
-   - **Other databases**: Run your migrations before enabling the flag:
-     ```bash
-     flask --app mcp_liquidation_map.main db init        # run once if migrations/ does not exist yet
-     flask --app mcp_liquidation_map.main db migrate -m "initial schema"
-     flask --app mcp_liquidation_map.main db upgrade
-     ```
-   Skip these commands if you do not plan to use the database features yet.
-
-6. **Run the server**:
-   ```bash
-   python -m mcp_liquidation_map.main
-   ```
-
-The server will start on `http://localhost:5001`
-
-### Example User Blueprint
-
-The `/api/users` endpoints provided by `src/mcp_liquidation_map/routes/user.py` demonstrate SQLAlchemy usage and are **opt-in**. To enable them:
-
-1. Prepare the database schema (see [Installation Step 5](#installation-and-setup)).
-   - SQLite users can rely on the automatic `db.create_all()` call; other databases must run migrations first.
-2. Set `ENABLE_USER_API=1` (or any truthy value) in your environment before starting the server.
-3. Generate and set a strong `USER_API_TOKEN` secret before exposing the endpoints:
-   ```bash
-   export USER_API_TOKEN="paste-a-random-string-here"
-   ```
-   Every request to `/api/users` must then include `Authorization: Bearer $USER_API_TOKEN`. When the token is missing the server
-   responds with `503 Service Unavailable`; mismatched or absent bearer tokens return `401 Unauthorized`.
-
-When disabled, the blueprint is not registered and the landing page hides the related UI controls. A new `/api/features` endpoint exposes the feature flag for client-side checks.
-
-## Logging
-
-The application configures Python's logging module during startup. By default it emits informational messages with timestamps
-and logger names. Hosting platforms that already configure logging will retain their handlers because the application only
-initializes logging when no handlers are present.
-
-You can customize the log level by setting the `APP_LOG_LEVEL` environment variable before starting the server:
+Use pytest to run the automated suite:
 
 ```bash
-export APP_LOG_LEVEL=DEBUG
-python -m mcp_liquidation_map.main
+pytest
 ```
 
-Any valid Python logging level name (e.g., `ERROR`, `WARNING`) is accepted.
-
-## Architecture
-
-### Core Components
-
-- **Flask Application**: Main web server framework
-- **Crypto Routes**: API endpoints for cryptocurrency operations
-- **BrowserCat Client**: Integration with Smithery's BrowserCat MCP for browser automation
-- **Error Handling**: Graceful fallbacks when external services are unavailable
-
-### File Structure
-
-```
-mcp-liquidation-map/
-├── src/
-│   ├── config.py                   # Environment-driven configuration
-│   ├── main.py                     # Main Flask application
-│   ├── routes/
-│   │   ├── crypto.py              # Cryptocurrency API endpoints
-│   │   └── user.py                # Example user routes blueprint (enable with ENABLE_USER_API)
-│   ├── services/
-│   │   └── browsercat_client.py   # BrowserCat MCP integration
-│   ├── models/                    # Database models (unused)
-│   ├── database/
-│   │   └── migrations/            # Alembic migration environment
-│   └── static/                    # Static files
-├── requirements.txt               # Python dependencies
-└── README.md                      # This file
-```
-
-## Configuration
-
-Set the following environment variables to customise the server. Values shown in parentheses are defaults used when a variable
-is not defined.
-
-- `BROWSERCAT_API_KEY`: BrowserCat API key for real heatmap captures (no default, simulated payloads used when unset). Get a free key at https://browsercat.xyz/mcp.
-- `BROWSERCAT_BASE_URL`: Override the BrowserCat MCP base URL (`https://server.smithery.ai/@dmaznest/browsercat-mcp-server`).
-- `DATABASE_URI`: Database connection string (`sqlite:///src/mcp_liquidation_map/database/app.db`).
-- `DEBUG`: Enable Flask debug mode when set to a truthy value (disabled by default).
-- `ENABLE_USER_API`: Opt into registering the example `/api/users` routes (disabled by default).
-- `SECRET_KEY`: Flask secret key used for session signing. Required when `DEBUG`
-  is false; omitted values cause startup to fail in production. When `DEBUG` is
-  true the app falls back to a development-only default (`dev-secret-key`).
-
-## Smithery MCP Integration
-
-This server integrates with Smithery's Model Context Protocol ecosystem:
-
-### BrowserCat MCP Server
-- **Default URL**: `https://server.smithery.ai/@dmaznest/browsercat-mcp-server` (override with `BROWSERCAT_BASE_URL` if needed)
-- **Purpose**: Browser automation for capturing Coinglass heatmaps
-- **Timeout**: Requests default to 30 seconds and can be adjusted via `BROWSERCAT_TIMEOUT`
-- **Tools Used**:
-  - `browsercat_navigate`: Navigate to web pages
-  - `browsercat_screenshot`: Capture screenshots
-  - `browsercat_click`: Click page elements
-  - `browsercat_evaluate`: Execute JavaScript
-
-### Fallback Behavior
-
-When BrowserCat MCP is unavailable (e.g., missing API key or service errors), the server provides simulated responses to ensure functionality continues. This makes the server robust and suitable for development/testing environments.
-
-## Supported Cryptocurrencies
-
-The server supports all major cryptocurrencies available on CoinGecko, including:
-- BTC (Bitcoin)
-- ETH (Ethereum)
-- BNB (Binance Coin)
-- ADA (Cardano)
-- SOL (Solana)
-- XRP (Ripple)
-- DOT (Polkadot)
-- DOGE (Dogecoin)
-- AVAX (Avalanche)
-- MATIC (Polygon)
-
-## Error Handling
-
-The server implements comprehensive error handling:
-
-1. **Invalid Parameters**: Returns 400 Bad Request with descriptive error messages
-2. **External Service Failures**: Graceful fallbacks with simulated responses
-3. **Network Issues**: Timeout handling and retry logic
-4. **API Rate Limits**: Proper HTTP status codes and error messages
-
-## Development and Testing
-
-### Running Tests
-
-Test the endpoints using curl:
+API smoke tests can be performed with curl:
 
 ```bash
-# Test health endpoint
 curl "http://localhost:5001/api/health"
-
-# Test crypto price
 curl "http://localhost:5001/api/get_crypto_price?symbol=BTC"
-
-# Test heatmap capture
 curl "http://localhost:5001/api/capture_heatmap?symbol=ETH&time_period=24%20hour"
 ```
 
 ### Linting
 
-We use [Ruff](https://docs.astral.sh/ruff/) to enforce import cleanliness and other Python style rules. Run the linter before
-opening a pull request:
+We use [Ruff](https://docs.astral.sh/ruff/) to keep imports tidy and enforce style rules.
 
 ```bash
 ruff check .
+ruff check --fix .  # Auto-fix simple issues
 ```
 
-Use `ruff check --fix .` to automatically resolve simple issues such as unused imports.
+### Database Migrations
 
-### Development Mode
-
-Debug mode is disabled by default for safety. Enable it during development by setting
-the `DEBUG` environment variable before starting the server:
+Flask-Migrate is configured for the optional user API. Typical workflow:
 
 ```bash
-export DEBUG=1
-python -m mcp_liquidation_map.main
+flask --app mcp_liquidation_map.main db init      # First run only
+flask --app mcp_liquidation_map.main db migrate
+flask --app mcp_liquidation_map.main db upgrade
 ```
 
-This enables automatic reloading on code changes and detailed error messages.
+SQLite users can rely on automatic schema creation when the API starts, but other databases require migrations to be applied manually.
 
-## Deployment
+## Deployment Notes
 
-For production deployment, consider:
+For production deployments:
 
-1. **Use a production WSGI server** (e.g., Gunicorn, uWSGI)
-2. **Set up environment variables** for API keys
-3. **Configure reverse proxy** (e.g., Nginx)
-4. **Enable HTTPS** for secure communication
-5. **Set up monitoring** and logging
-6. **Copy the custom Marshmallow shim when containerizing** so the
-   `marshmallow/` compatibility layer is available at runtime (see the Docker
-   example in `DEPLOYMENT_GUIDE.md`).
+1. Run behind a production WSGI server (Gunicorn, uWSGI, etc.).
+2. Provide all sensitive configuration via environment variables or a secrets manager.
+3. Place a reverse proxy (e.g., Nginx) in front of the service and enable HTTPS.
+4. Configure logging/monitoring (CloudWatch, Prometheus, etc.) and alerting on failures.
+5. Copy the `marshmallow/` compatibility shim when containerising so the app can import the bundled schema patches (see `DEPLOYMENT_GUIDE.md`).
 
-## License
+## Troubleshooting
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+1. **Heatmap calls fail immediately** – Verify `BROWSERCAT_API_KEY` and network access to the BrowserCat MCP server.
+2. **Fallbacks not provided** – Ensure `allow_simulated=true` or `ENABLE_SIMULATED_HEATMAP=1` is set while testing without BrowserCat.
+3. **User API returns 503** – Check that `USER_API_TOKEN` is set and that migrations have been run (or SQLite schema created).
+4. **App refuses to start in production** – Set `SECRET_KEY` and confirm `DEBUG=0`.
+5. **Database errors on SQLite** – The project stores SQLite files under `src/mcp_liquidation_map/database/`; ensure the process has write permissions.
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Add tests if applicable
-5. Submit a pull request
-
-## Support
-
-For issues and questions:
-1. Check the error logs in the console
-2. Verify API keys are correctly set
-3. Ensure all dependencies are installed
-4. Check network connectivity to external services
+1. Fork the repository and create a feature branch.
+2. Install development dependencies and activate a virtual environment.
+3. Implement your change with tests and lint fixes.
+4. Open a pull request describing the change and how to validate it.
 
 ## Changelog
 
 ### v0.1.0
-- Initial release
-- Cryptocurrency price fetching via CoinGecko API
-- BrowserCat MCP integration for heatmap capture
-- RESTful API endpoints
-- Comprehensive error handling and fallbacks
+- Initial release with CoinGecko pricing, BrowserCat heatmaps, RESTful API endpoints, and comprehensive fallback handling.
 
+## License
+
+This project is licensed under the MIT License. See [`LICENSE`](LICENSE) for details.


### PR DESCRIPTION
## Summary
- restructure the README to surface key features, quick start instructions, configuration details, and API reference content
- document environment variables, BrowserCat integration, optional user API, development workflow, and troubleshooting guidance for clearer onboarding

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68de667a55048332acc19a62a7723531